### PR TITLE
Fix import wizard Supabase client

### DIFF
--- a/pages/products/index.js
+++ b/pages/products/index.js
@@ -5,6 +5,8 @@ import organizationService from '/core/services/organization-service.js';
 import { importWizard } from '/core/import-wizard.js';
 import { supabase } from '/core/services/supabase-client.js';
 importWizard.setSupabaseClient(supabase);
+// Expose supabase globally for modules expecting window.supabase
+window.supabase = supabase;
 console.log('[DEBUG] Supabase client in wizard:', window.importWizard.supabase);
 
 class ProductIntelligenceSystem {
@@ -140,7 +142,7 @@ showStatus(message, type = 'info', duration = 3000) {
         return;
     }
     // Passa il Supabase client all’importWizard
-    window.importWizard.setSupabaseClient(window.supabase);
+    window.importWizard.setSupabaseClient(supabase);
     await window.importWizard.init({
         entity: 'products',
         allowCustomFields: true,


### PR DESCRIPTION
## Summary
- keep a global Supabase instance for other modules
- use the imported client when launching the import wizard

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686ae5a206e4832494489ea11d2e6297