### PR TITLE
Improve Supabase client check in startImport

### DIFF
--- a/core/import-wizard.js
+++ b/core/import-wizard.js
@@ -1123,7 +1123,17 @@ startImport = async () => {
             notificationSystem.show("Missing organization context. Cannot proceed with import.", "error");
             return;
         }
-        const supa = this.supabase || supabase;
+        const supa = this.supabase || window.supabase || supabase;
+        const supaSource = this.supabase
+            ? 'instance'
+            : window.supabase
+                ? 'window.supabase'
+                : 'default import';
+        console.log(`[ImportWizard] Using Supabase client from ${supaSource}`);
+        if (!supa || !supa.auth) {
+            notificationSystem.show('Supabase client not available', 'error');
+            return;
+        }
         const user = await supa.auth.getUser();
         const userId = user?.data?.user?.id;
         if (!userId) {


### PR DESCRIPTION
## Summary
- check for Supabase client in `startImport`
- log which Supabase instance is used
- notify user when the client is missing

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686aec192de08324a48133433af1e0d9