### PR TITLE
Improve mapping retry logic

### DIFF
--- a/core/import-wizard.js
+++ b/core/import-wizard.js
@@ -1016,25 +1016,29 @@ showStep = (step) => {
 
   // === PATCH: Render mapping columns SOLO nello step "mapping" ===
   if (step === 'mapping') {
-  const tryRenderMapping = () => {
-    if (
-      this.targetFields &&
-      Array.isArray(this.targetFields) &&
-      this.targetFields.length > 0 &&
-      this.headers &&
-      Array.isArray(this.headers) &&
-      this.headers.length > 0 &&
-      this.modal.querySelector('#sourceColumns') &&
-      this.modal.querySelector('#targetFields')
-    ) {
-      this.renderSourceColumns();
-      this.renderTargetFields();
-    } else {
-      setTimeout(tryRenderMapping, 100);
-    }
-  };
-  setTimeout(tryRenderMapping, 0);
-}
+    const maxRetries = 20;
+    const retryDelay = 200;
+    const tryRenderMapping = (attempt = 0) => {
+      const sourceEl = this.modal.querySelector('#sourceColumns');
+      const targetEl = this.modal.querySelector('#targetFields');
+      if (
+        sourceEl &&
+        targetEl &&
+        Array.isArray(this.targetFields) &&
+        this.targetFields.length > 0 &&
+        Array.isArray(this.headers) &&
+        this.headers.length > 0
+      ) {
+        this.renderSourceColumns();
+        this.renderTargetFields();
+      } else if (attempt < maxRetries) {
+        setTimeout(() => tryRenderMapping(attempt + 1), retryDelay);
+      } else {
+        console.warn('Mapping UI not ready after', attempt, 'attempts');
+      }
+    };
+    setTimeout(() => tryRenderMapping(), retryDelay);
+  }
 };
 
 


### PR DESCRIPTION
## Summary
- check for source/target containers when rendering mapping UI
- retry mapping render longer and warn if attempts fail

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686aec2ec5248324a30f43e91a1798a1