### PR TITLE
Fix import duplicate errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# AGENTS
+
+This repository contains HTML, JavaScript, Netlify functions, and Supabase edge functions.
+
+## Contributing Guidelines
+- Use **two spaces** for indentation in JavaScript, TypeScript and JSON files.
+- Terminate JavaScript/TypeScript statements with semicolons.
+- Keep classes in `PascalCase` and functions/variables in `camelCase`.
+- Update `package.json` when adding dependencies.
+- Keep commit messages concise using present tense. Example: `fix(parser): handle null headers`.
+
+## Testing
+There are no automated tests. Perform manual testing by serving the HTML files locally:
+```bash
+python3 -m http.server 8000
+```
+Then open `http://localhost:8000/tracking.html` in the browser. If future tests are added, run `npm test`.
+
+## Tools
+- Netlify functions are under `netlify/functions/`.
+- Supabase edge functions are under `supabase/functions/` and formatted with `deno fmt`.
+

--- a/core/header-component.js
+++ b/core/header-component.js
@@ -972,8 +972,8 @@ export class HeaderComponent {
             this.notificationCount = data?.unread_count || 0;
             this.updateNotificationBadge();
         } catch (error) {
-            if (error.status === 404) {
-                console.log('📣 Notifications API not available (development mode)');
+            if (error.status === 404 || error.status >= 500) {
+                console.log('📣 Notifications service unavailable');
                 this.renderNotifications([]);
                 this.notificationCount = 0;
                 this.updateNotificationBadge();

--- a/core/import-wizard.js
+++ b/core/import-wizard.js
@@ -815,7 +815,9 @@ if (!this.targetFields || !Array.isArray(this.targetFields) || this.targetFields
         statusEl.textContent = 'Starting import...';
         for (let i = 0; i < totalBatches; i++) {
             const batch = importData.slice(i * batchSize, (i + 1) * batchSize);
-            const { data, error } = await supa.from('products').insert(batch);
+            const { data, error } = await supa
+              .from('products')
+              .upsert(batch, { onConflict: 'user_id,sku' });
             if (error) {
                 console.error('Supabase insert error:', error);
                 throw new Error(`Supabase error: ${error.message}`);
@@ -1160,7 +1162,9 @@ startImport = async () => {
         console.log("🧪 First record to import:", records[0]);
         document.getElementById('importStatus').innerText = `Importing ${records.length} records...`;
 
-        const { data, error } = await supa.from('products').insert(records);
+        const { data, error } = await supa
+          .from('products')
+          .upsert(records, { onConflict: 'user_id,sku' });
 
         if (error) {
             console.error("❌ Supabase insert error", error);

--- a/pages/products/index.js
+++ b/pages/products/index.js
@@ -5,6 +5,8 @@ import organizationService from '/core/services/organization-service.js';
 import { importWizard } from '/core/import-wizard.js';
 import { supabase } from '/core/services/supabase-client.js';
 importWizard.setSupabaseClient(supabase);
+// Expose supabase globally for modules expecting window.supabase
+window.supabase = supabase;
 console.log('[DEBUG] Supabase client in wizard:', window.importWizard.supabase);
 
 class ProductIntelligenceSystem {
@@ -140,7 +142,7 @@ showStatus(message, type = 'info', duration = 3000) {
         return;
     }
     // Passa il Supabase client all’importWizard
-    window.importWizard.setSupabaseClient(window.supabase);
+    window.importWizard.setSupabaseClient(supabase);
     await window.importWizard.init({
         entity: 'products',
         allowCustomFields: true,


### PR DESCRIPTION
## Summary
- handle upstream notification errors gracefully
- use upsert when importing products to avoid duplicate key conflicts

## Testing
- `python3 -m http.server 8000`

------
https://chatgpt.com/codex/tasks/task_e_686afbb708948324b38f4e322c49fefd