### PR TITLE
Handle notification errors and restore product view toggle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# AGENTS
+
+This repository contains HTML, JavaScript, Netlify functions, and Supabase edge functions.
+
+## Contributing Guidelines
+- Use **two spaces** for indentation in JavaScript, TypeScript and JSON files.
+- Terminate JavaScript/TypeScript statements with semicolons.
+- Keep classes in `PascalCase` and functions/variables in `camelCase`.
+- Update `package.json` when adding dependencies.
+- Keep commit messages concise using present tense. Example: `fix(parser): handle null headers`.
+
+## Testing
+There are no automated tests. Perform manual testing by serving the HTML files locally:
+```bash
+python3 -m http.server 8000
+```
+Then open `http://localhost:8000/tracking.html` in the browser. If future tests are added, run `npm test`.
+
+## Tools
+- Netlify functions are under `netlify/functions/`.
+- Supabase edge functions are under `supabase/functions/` and formatted with `deno fmt`.
+

--- a/core/header-component.js
+++ b/core/header-component.js
@@ -972,7 +972,7 @@ export class HeaderComponent {
             this.notificationCount = data?.unread_count || 0;
             this.updateNotificationBadge();
         } catch (error) {
-            if (error.status === 404) {
+            if (error.status === 404 || error.status === 502) {
                 console.log('📣 Notifications API not available (development mode)');
                 this.renderNotifications([]);
                 this.notificationCount = 0;

--- a/core/import-wizard.js
+++ b/core/import-wizard.js
@@ -1160,7 +1160,9 @@ startImport = async () => {
         console.log("🧪 First record to import:", records[0]);
         document.getElementById('importStatus').innerText = `Importing ${records.length} records...`;
 
-        const { data, error } = await supa.from('products').insert(records);
+        const { data, error } = await supa
+          .from('products')
+          .upsert(records, { onConflict: 'user_id,sku' });
 
         if (error) {
             console.error("❌ Supabase insert error", error);

--- a/pages/products/index.js
+++ b/pages/products/index.js
@@ -5,6 +5,8 @@ import organizationService from '/core/services/organization-service.js';
 import { importWizard } from '/core/import-wizard.js';
 import { supabase } from '/core/services/supabase-client.js';
 importWizard.setSupabaseClient(supabase);
+// Expose supabase globally for modules expecting window.supabase
+window.supabase = supabase;
 console.log('[DEBUG] Supabase client in wizard:', window.importWizard.supabase);
 
 class ProductIntelligenceSystem {
@@ -140,7 +142,7 @@ showStatus(message, type = 'info', duration = 3000) {
         return;
     }
     // Passa il Supabase client all’importWizard
-    window.importWizard.setSupabaseClient(window.supabase);
+    window.importWizard.setSupabaseClient(supabase);
     await window.importWizard.init({
         entity: 'products',
         allowCustomFields: true,

--- a/pages/products/index.js
+++ b/pages/products/index.js
@@ -15,7 +15,7 @@ class ProductIntelligenceSystem {
     this.analytics = {};
     this.recommendations = [];
     this.organizationId = null;
-    this.viewMode = 'list';
+    this.viewMode = 'grid';
     this.sortColumn = 'name';
     this.sortDirection = 'asc';
     this.availableColumns = [
@@ -89,6 +89,11 @@ initializeEventHandlers() {
 
     const columnBtn = document.getElementById('columnSelectorBtn');
     if (columnBtn) columnBtn.onclick = () => this.showColumnSelector();
+
+    const gridBtn = document.getElementById('viewGridBtn');
+    const listBtn = document.getElementById('viewListBtn');
+    if (gridBtn) gridBtn.onclick = () => this.toggleViewMode('grid');
+    if (listBtn) listBtn.onclick = () => this.toggleViewMode('list');
 }
 
 showStatus(message, type = 'info', duration = 3000) {
@@ -375,8 +380,13 @@ showStatus(message, type = 'info', duration = 3000) {
     renderProducts() {
         const productsGrid = document.getElementById('productsGrid');
         if (!productsGrid) return;
-        productsGrid.className = 'products-intelligence-list';
-        productsGrid.innerHTML = this.renderProductsList();
+        if (this.viewMode === 'grid') {
+            productsGrid.className = 'products-intelligence-grid';
+            productsGrid.innerHTML = this.renderProductsGrid();
+        } else {
+            productsGrid.className = 'products-intelligence-list';
+            productsGrid.innerHTML = this.renderProductsList();
+        }
     }
 
     renderProductsGrid() {
@@ -1057,8 +1067,8 @@ showStatus(message, type = 'info', duration = 3000) {
         });
     }
 
-    toggleViewMode() {
-        this.viewMode = this.viewMode === 'grid' ? 'list' : 'grid';
+    toggleViewMode(mode = null) {
+        this.viewMode = mode || (this.viewMode === 'grid' ? 'list' : 'grid');
         this.renderProducts();
         const gridBtn = document.getElementById('viewGridBtn');
         const listBtn = document.getElementById('viewListBtn');

--- a/products.html
+++ b/products.html
@@ -143,6 +143,14 @@
                 <div class="sol-card-header">
                     <h3 class="sol-card-title">Product Management</h3>
                     <div class="sol-card-filters">
+                        <div class="view-toggle-buttons">
+                            <button class="sol-btn sol-btn-glass active" id="viewGridBtn">
+                                <i class="fas fa-th"></i> Grid
+                            </button>
+                            <button class="sol-btn sol-btn-glass" id="viewListBtn">
+                                <i class="fas fa-list"></i> List
+                            </button>
+                        </div>
                         <button class="sol-btn sol-btn-glass" id="columnSelectorBtn">
                             <i class="fas fa-columns"></i> Columns
                         </button>
@@ -647,8 +655,23 @@
         .product-menu button:hover {
             background: var(--sol-gray-100);
         }
-        
-        
+
+        /* View Toggle Buttons */
+        .view-toggle-buttons {
+          display: flex;
+          gap: 0.5rem;
+          margin-right: 1rem;
+        }
+
+        .view-toggle-buttons .sol-btn {
+          padding: 0.5rem 1rem;
+        }
+
+        .view-toggle-buttons .sol-btn.active {
+          background: var(--sol-primary);
+          color: white;
+        }
+
         /* Advanced Filters Button */
         .advanced-filters-btn {
             position: relative;
@@ -970,6 +993,11 @@
                 flex-direction: column;
                 gap: 1rem;
                 align-items: stretch;
+            }
+
+            .view-toggle-buttons {
+                margin-right: 0;
+                margin-bottom: 0.5rem;
             }
 
         }

--- a/products.html
+++ b/products.html
@@ -143,15 +143,9 @@
                 <div class="sol-card-header">
                     <h3 class="sol-card-title">Product Management</h3>
                     <div class="sol-card-filters">
-                        <<div class="view-toggle-buttons">
-    <button class="sol-btn sol-btn-glass active" id="viewGridBtn" onclick="window.productIntelligenceSystem.toggleViewMode('grid')">
-        <i class="fas fa-th"></i> Grid
-    </button>
-    <button class="sol-btn sol-btn-glass" id="viewListBtn" onclick="window.productIntelligenceSystem.toggleViewMode('list')">
-        <i class="fas fa-list"></i> List
-    </button>
-</div>
-                        </div>
+                        <button class="sol-btn sol-btn-glass" id="columnSelectorBtn">
+                            <i class="fas fa-columns"></i> Columns
+                        </button>
                         <select class="sol-select" id="categoryFilter">
                             <option value="">All Categories</option>
                             <option value="electronics">Electronics</option>
@@ -178,32 +172,8 @@
                 </div>
             </div>
 
-            <!-- Products Grid View -->
-            <div id="productsGrid" class="products-intelligence-grid">
+            <div id="productsGrid" class="products-intelligence-list">
                 <!-- Populated by JS -->
-            </div>
-
-            <!-- Products List View -->
-            <div id="productsList" class="products-intelligence-list" style="display: none;">
-                <div class="products-list-table">
-                    <table>
-                        <thead>
-                            <tr>
-                                <th>Product</th>
-                                <th>SKU</th>
-                                <th>Category</th>
-                                <th class="text-right">Shipping Cost</th>
-                                <th class="text-right">Cost Trend</th>
-                                <th class="text-right">Monthly Volume</th>
-                                <th class="text-right">Profit Impact</th>
-                                <th class="text-right">Actions</th>
-                            </tr>
-                        </thead>
-                        <tbody id="productsListBody">
-                            <!-- Populated by JS -->
-                        </tbody>
-                    </table>
-                </div>
             </div>
         </div>
 
@@ -654,22 +624,30 @@
             display: flex;
             gap: 0.5rem;
         }
-        
-        /* View Toggle Buttons */
-        .view-toggle-buttons {
-            display: flex;
-            gap: 0.5rem;
-            margin-right: 1rem;
+
+        .product-menu {
+            position: absolute;
+            background: white;
+            border: 1px solid var(--sol-gray-200);
+            box-shadow: var(--sol-shadow-sm);
+            border-radius: var(--sol-radius-sm);
+            padding: 0.25rem 0;
+            z-index: 1000;
         }
-        
-        .view-toggle-buttons .sol-btn {
+
+        .product-menu button {
+            display: block;
+            width: 100%;
             padding: 0.5rem 1rem;
+            background: none;
+            border: none;
+            text-align: left;
+        }
+
+        .product-menu button:hover {
+            background: var(--sol-gray-100);
         }
         
-        .view-toggle-buttons .sol-btn.active {
-            background: var(--sol-primary);
-            color: white;
-        }
         
         /* Advanced Filters Button */
         .advanced-filters-btn {
@@ -994,10 +972,6 @@
                 align-items: stretch;
             }
 
-            .view-toggle-buttons {
-                margin-right: 0;
-                margin-bottom: 0.5rem;
-            }
         }
         /* ===== FIX MODAL FULLSCREEN ===== */
 .sol-modal-content {


### PR DESCRIPTION
## Summary
- treat 502 errors for notifications as unavailable
- reintroduce toggleViewMode to switch grid/list views
- add getEmptyAnalytics and getSortIcon helpers
- simplify products list view
- add column selector modal

## Testing
- `python3 -m http.server 8000` *(no output)*

------
https://chatgpt.com/codex/tasks/task_e_686afbb708948324b38f4e322c49fefd