### PR TITLE
Enforce list-only products view

### DIFF
--- a/pages/products/index.js
+++ b/pages/products/index.js
@@ -15,7 +15,7 @@ class ProductIntelligenceSystem {
   this.analytics = {};
   this.recommendations = [];
   this.organizationId = null;
-  this.viewMode = 'grid';
+  this.viewMode = 'list';
   this.allColumns = [
   { key: 'sku', label: 'SKU' },
   { key: 'name', label: 'Product Name' },
@@ -380,13 +380,8 @@ showStatus(message, type = 'info', duration = 3000) {
   renderProducts() {
     const productsGrid = document.getElementById('productsGrid');
     if (!productsGrid) return;
-    if (this.viewMode === 'grid') {
-      productsGrid.className = 'products-intelligence-grid';
-      productsGrid.innerHTML = this.renderProductsGrid();
-    } else {
-      productsGrid.className = 'products-intelligence-list';
-      productsGrid.innerHTML = this.renderProductsList();
-    }
+    productsGrid.className = 'products-intelligence-list';
+    productsGrid.innerHTML = this.renderProductsList();
   }
 
   renderProductsGrid() {
@@ -1023,19 +1018,7 @@ showStatus(message, type = 'info', duration = 3000) {
   }
 
   toggleViewMode() {
-    this.viewMode = this.viewMode === 'grid' ? 'list' : 'grid';
-    this.renderProducts();
-    const gridBtn = document.getElementById('viewGridBtn');
-    const listBtn = document.getElementById('viewListBtn');
-    if (gridBtn && listBtn) {
-      if (this.viewMode === 'grid') {
-        gridBtn.classList.add('active');
-        listBtn.classList.remove('active');
-      } else {
-        gridBtn.classList.remove('active');
-        listBtn.classList.add('active');
-      }
-    }
+    // View mode is fixed to list; no toggle behavior
   }
 
 } // END CLASS

--- a/products.html
+++ b/products.html
@@ -143,14 +143,7 @@
                 <div class="sol-card-header">
                     <h3 class="sol-card-title">Product Management</h3>
                     <div class="sol-card-filters">
-                        <div class="view-toggle-buttons">
-                            <button class="sol-btn sol-btn-glass active" id="viewGridBtn">
-                                <i class="fas fa-th"></i> Grid
-                            </button>
-                            <button class="sol-btn sol-btn-glass" id="viewListBtn">
-                                <i class="fas fa-list"></i> List
-                            </button>
-                        </div>
+                        <!-- View toggle removed: list view only -->
                         <button class="sol-btn sol-btn-glass" id="columnSelectorBtn">
                             <i class="fas fa-columns"></i> Columns
                         </button>


### PR DESCRIPTION
## Summary
- default to list view in product intelligence
- remove view toggle buttons from products page
- simplify render logic and disable toggle function

## Testing
- `python3 -m http.server 8000`

------
https://chatgpt.com/codex/tasks/task_e_686b15ed778083249b7713adf8cfe369