### PR TITLE
Fix modal closing logic for updating products

### DIFF
--- a/pages/products/index.js
+++ b/pages/products/index.js
@@ -962,7 +962,10 @@ showStatus(message, type = 'info', duration = 3000) {
       {
         label: 'Update Product',
         class: 'sol-btn-primary',
-        handler: () => this.updateProduct(productId)
+        handler: async () => {
+          const ok = await this.updateProduct(productId);
+          return ok;
+        }
       }
     ]
   });


### PR DESCRIPTION
## Summary
- only close the Edit Product modal after update succeeds

## Testing
- `npm test` *(fails: no test specified)*
- `python3 -m http.server 8000` *(manual testing placeholder)*

------
https://chatgpt.com/codex/tasks/task_e_686b15f30f2c8324b01c01c752406714