### PR TITLE
Restore getSortIcon helper

### DIFF
--- a/pages/products/index.js
+++ b/pages/products/index.js
@@ -296,6 +296,15 @@ showStatus(message, type = 'info', duration = 3000) {
         });
         return filteredProducts;
     }
+
+    getSortIcon(column) {
+        if (this.sortColumn !== column) {
+            return '<i class="fas fa-sort"></i>';
+        }
+        return this.sortDirection === 'asc'
+            ? '<i class="fas fa-sort-up"></i>'
+            : '<i class="fas fa-sort-down"></i>';
+    }
     // --- RENDERING ---
     renderIntelligenceStats() {
         const statsContainer = document.getElementById('intelligenceStats');


### PR DESCRIPTION
## Summary
- recover getSortIcon helper in products page

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686bb2dcea308324b989b3d3cad8b849