### PR TITLE
Fix product form data defaults

### DIFF
--- a/pages/products/index.js
+++ b/pages/products/index.js
@@ -572,24 +572,28 @@ showStatus(message, type = 'info', duration = 3000) {
     // --- FORM ---
     getProductFormHTML(product = null) {
         const isEdit = product !== null;
-        const data = product || {
-            sku: '',
-            name: '',
-            category: 'electronics',
-            description: '',
+        const data = {
+            sku: product?.sku ?? '',
+            name: product?.name ?? '',
+            category: product?.category ?? 'electronics',
+            description: product?.description ?? '',
             specifications: {
-                weight: 0,
-                dimensions: { length: 0, width: 0, height: 0 },
-                value: 0,
-                hsCode: '',
-                fragile: false,
-                hazardous: false
+                weight: product?.specifications?.weight ?? 0,
+                dimensions: {
+                    length: product?.specifications?.dimensions?.length ?? 0,
+                    width: product?.specifications?.dimensions?.width ?? 0,
+                    height: product?.specifications?.dimensions?.height ?? 0,
+                },
+                value: product?.specifications?.value ?? 0,
+                hsCode: product?.specifications?.hsCode ?? '',
+                fragile: product?.specifications?.fragile ?? false,
+                hazardous: product?.specifications?.hazardous ?? false
             },
             costTracking: {
-                baseCost: 0,
-                targetMargin: 0.30,
-                shippingBudget: 0,
-                currencyCode: 'USD'
+                baseCost: product?.costTracking?.baseCost ?? 0,
+                targetMargin: product?.costTracking?.targetMargin ?? 0.30,
+                shippingBudget: product?.costTracking?.shippingBudget ?? 0,
+                currencyCode: product?.costTracking?.currencyCode ?? 'USD'
             }
         };
         return `


### PR DESCRIPTION
## Summary
- guard against undefined costTracking/specifications fields when building product form

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686bb89b4e048324b6b67007aac617af