### PR TITLE
Expose global supabase client for import wizard

### DIFF
--- a/pages/products/index.js
+++ b/pages/products/index.js
@@ -4,6 +4,7 @@
 import organizationService from '/core/services/organization-service.js';
 import { importWizard } from '/core/import-wizard.js';
 import { supabase } from '/core/services/supabase-client.js';
+window.supabase = supabase;
 importWizard.setSupabaseClient(supabase);
 console.log('[DEBUG] Supabase client in wizard:', window.importWizard.supabase);
 


### PR DESCRIPTION
## Summary
- make the Supabase client globally available

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686bbc5c44908324959cf506c7066fae