### PR TITLE
Add drag handle to table headers

### DIFF
--- a/core/table-manager.js
+++ b/core/table-manager.js
@@ -293,12 +293,13 @@ export class TableManager {
             : 'fa-sort';
         
         return `
-            <th 
+            <th
                 class="${column.sortable !== false ? 'sortable' : ''} ${column.className || ''}"
                 data-column="${column.key}"
                 ${column.sortable !== false ? `onclick="window.tableManagerSort('${this.container.id}', '${column.key}')"` : ''}
             >
                 <div class="th-content">
+                    ${this.options.enableColumnDrag ? '<span class="drag-handle"><i class="fas fa-grip-lines"></i></span>' : ''}
                     <span>${column.label || column.key}</span>
                     ${column.sortable !== false ? `<i class="fas ${sortIcon} sort-icon"></i>` : ''}
                 </div>


### PR DESCRIPTION
## Summary
- update `renderHeader` to add a grip icon handle when column drag is enabled

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686bcd4b77dc83248158b3ecbd197950