### PR TITLE
Expose column configs globally

### DIFF
--- a/pages/products/index.js
+++ b/pages/products/index.js
@@ -29,6 +29,8 @@ export const DEFAULT_VISIBLE_COLUMNS = [
     'sku', 'name', 'category', 'avgShippingCost', 'costTrend',
     'totalUnitsShipped', 'profitImpact', 'statusBadge', 'actions'
 ];
+// Provide default visible columns globally for consistency
+window.DEFAULT_VISIBLE_COLUMNS = DEFAULT_VISIBLE_COLUMNS;
 
 export const TABLE_COLUMNS = [
     {


### PR DESCRIPTION
## Summary
- expose `DEFAULT_VISIBLE_COLUMNS` to the global window object for consistency

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686bd2ecf1788324a4ef1744f9766f20