### PR TITLE
feat: add supabase shipments service

### DIFF
--- a/core/services/supabase-shipments-service.js
+++ b/core/services/supabase-shipments-service.js
@@ -1,0 +1,102 @@
+import { supabase } from '/core/services/supabase-client.js';
+
+class SupabaseShipmentsService {
+    constructor() {
+        this.table = 'shipments';
+        this.realtimeSubscription = null;
+    }
+
+    // ========================================
+    // CRUD OPERATIONS
+    // ========================================
+
+    async getAllShipments() {
+        try {
+            const { data, error } = await supabase
+                .from(this.table)
+                .select('*')
+                .order('created_at', { ascending: false });
+
+            if (error) throw error;
+
+            console.log(`\u2705 Loaded ${data.length} shipments from Supabase`);
+            return data;
+        } catch (error) {
+            console.error('\u274C Error loading shipments:', error);
+            return [];
+        }
+    }
+
+    async getShipment(id) {
+        try {
+            const { data, error } = await supabase
+                .from(this.table)
+                .select('*')
+                .eq('id', id)
+                .single();
+
+            if (error) throw error;
+            return data;
+        } catch (error) {
+            console.error('\u274C Error getting shipment:', error);
+            return null;
+        }
+    }
+
+    async createShipment(shipmentData) {
+        try {
+            const { data, error } = await supabase
+                .from(this.table)
+                .insert([shipmentData])
+                .select()
+                .single();
+
+            if (error) throw error;
+
+            console.log('\u2705 Shipment created in Supabase:', data.id);
+            return data;
+        } catch (error) {
+            console.error('\u274C Error creating shipment:', error);
+            return null;
+        }
+    }
+
+    async updateShipment(id, updates) {
+        try {
+            const { data, error } = await supabase
+                .from(this.table)
+                .update(updates)
+                .eq('id', id)
+                .select()
+                .single();
+
+            if (error) throw error;
+
+            console.log('\u2705 Shipment updated in Supabase:', id);
+            return data;
+        } catch (error) {
+            console.error('\u274C Error updating shipment:', error);
+            return null;
+        }
+    }
+
+    async deleteShipment(id) {
+        try {
+            const { error } = await supabase
+                .from(this.table)
+                .delete()
+                .eq('id', id);
+
+            if (error) throw error;
+
+            console.log('\u2705 Shipment deleted from Supabase:', id);
+            return true;
+        } catch (error) {
+            console.error('\u274C Error deleting shipment:', error);
+            return false;
+        }
+    }
+}
+
+export const supabaseShipmentsService = new SupabaseShipmentsService();
+export default supabaseShipmentsService;

--- a/shipments.html
+++ b/shipments.html
@@ -24,12 +24,21 @@
         import headerComponent from '/core/header-component.js';
         import notificationSystem from '/core/notification-system.js';
         import modalSystem from '/core/modal-system.js';
-        
+        import organizationService from '/core/services/organization-service.js';
+        import { supabase } from '/core/services/supabase-client.js';
+        import supabaseShipmentsService from '/core/services/supabase-shipments-service.js';
+
         // Make modules available globally
         window.api = api;
         window.headerComponent = headerComponent;
         window.NotificationSystem = notificationSystem;
         window.ModalSystem = modalSystem;
+        window.organizationService = organizationService;
+        window.supabase = supabase;
+        window.supabaseShipmentsService = supabaseShipmentsService;
+
+        // Initialize header after globals are set
+        headerComponent.init();
     </script>
     
     <script src="/core/product-sync.js"></script>


### PR DESCRIPTION
## Summary
- import new shipments services in the shipments page
- expose global references for organization and Supabase
- initialize the header after globals set
- implement `supabase-shipments-service` with CRUD helpers

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686c0de127348324ba4b9d933666a01f