### PR TITLE
Add organization-aware shipments management

### DIFF
--- a/core/services/supabase-shipments-service.js
+++ b/core/services/supabase-shipments-service.js
@@ -1,4 +1,5 @@
 import { supabase } from '/core/services/supabase-client.js';
+import organizationService from '/core/services/organization-service.js';
 
 class SupabaseShipmentsService {
     constructor() {
@@ -11,10 +12,12 @@ class SupabaseShipmentsService {
     // ========================================
 
     async getAllShipments() {
+        const orgId = organizationService.getCurrentOrgId();
         try {
             const { data, error } = await supabase
                 .from(this.table)
                 .select('*')
+                .eq('organization_id', orgId)
                 .order('created_at', { ascending: false });
 
             if (error) throw error;
@@ -28,11 +31,13 @@ class SupabaseShipmentsService {
     }
 
     async getShipment(id) {
+        const orgId = organizationService.getCurrentOrgId();
         try {
             const { data, error } = await supabase
                 .from(this.table)
                 .select('*')
                 .eq('id', id)
+                .eq('organization_id', orgId)
                 .single();
 
             if (error) throw error;
@@ -44,10 +49,11 @@ class SupabaseShipmentsService {
     }
 
     async createShipment(shipmentData) {
+        const orgId = organizationService.getCurrentOrgId();
         try {
             const { data, error } = await supabase
                 .from(this.table)
-                .insert([shipmentData])
+                .insert([{ ...shipmentData, organization_id: orgId }])
                 .select()
                 .single();
 
@@ -62,11 +68,13 @@ class SupabaseShipmentsService {
     }
 
     async updateShipment(id, updates) {
+        const orgId = organizationService.getCurrentOrgId();
         try {
             const { data, error } = await supabase
                 .from(this.table)
                 .update(updates)
                 .eq('id', id)
+                .eq('organization_id', orgId)
                 .select()
                 .single();
 
@@ -81,11 +89,13 @@ class SupabaseShipmentsService {
     }
 
     async deleteShipment(id) {
+        const orgId = organizationService.getCurrentOrgId();
         try {
             const { error } = await supabase
                 .from(this.table)
                 .delete()
-                .eq('id', id);
+                .eq('id', id)
+                .eq('organization_id', orgId);
 
             if (error) throw error;
 

--- a/pages/shipments/registry-core.js
+++ b/pages/shipments/registry-core.js
@@ -88,7 +88,13 @@ class RegistryCore {
     }
     
     createFallbackRegistry() {
-        const storageKeys = ['shipmentsRegistry', 'shipments', 'SCH_Shipments'];
+        const orgId = window.organizationService?.getCurrentOrgId();
+        const storageKeys = [
+            `shipmentsRegistry_${orgId}`,
+            'shipmentsRegistry',
+            'shipments',
+            'SCH_Shipments'
+        ];
         
         for (const key of storageKeys) {
             try {
@@ -802,8 +808,9 @@ class RegistryCore {
                         const index = this.registry.shipments.findIndex(s => s.id === shipmentId);
                         if (index >= 0) {
                             this.registry.shipments.splice(index, 1);
-                            if (localStorage.getItem('shipmentsRegistry')) {
-                                localStorage.setItem('shipmentsRegistry', JSON.stringify(this.registry.shipments));
+                            const key = `shipmentsRegistry_${window.organizationService?.getCurrentOrgId()}`;
+                            if (localStorage.getItem(key)) {
+                                localStorage.setItem(key, JSON.stringify(this.registry.shipments));
                             }
                         }
                     }

--- a/shipments.html
+++ b/shipments.html
@@ -3018,7 +3018,11 @@ MSCU7654321,PO-2024-002,22000,PI-2024-002,22000,CI-2024-002,22000,BL-2024-002,CI
        // Enhanced page initialization with Executive BI support
        document.addEventListener('DOMContentLoaded', async () => {
            console.log('🚢 Initializing Enhanced Shipments Registry with Executive BI...');
-           
+
+           if (window.organizationService && !window.organizationService.initialized) {
+               await window.organizationService.init();
+           }
+
            // // Initialize header
            // if (window.headerComponent) {
            //     await window.headerComponent.init();
@@ -3311,7 +3315,8 @@ MSCU7654321,PO-2024-002,22000,PI-2024-002,22000,CI-2024-002,22000,BL-2024-002,CI
            }
            
            // MVP: Load from localStorage first
-           const savedShipments = localStorage.getItem('shipmentsRegistry');
+           const orgId = window.organizationService?.getCurrentOrgId();
+           const savedShipments = localStorage.getItem(`shipmentsRegistry_${orgId}`);
            if (savedShipments) {
                try {
                    const parsed = JSON.parse(savedShipments);


### PR DESCRIPTION
## Summary
- scope Supabase shipment queries by organization id
- store shipments in localStorage per organization
- adjust registry fallback and deletion logic
- initialize shipments page with current organization context

## Testing
- `npx -y -p node@18 npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686c1aa42ab88324ab2d05d22b4cd596