### PR TITLE
Add trackingAdded event integration

### DIFF
--- a/core/auto-sync-system.js
+++ b/core/auto-sync-system.js
@@ -110,7 +110,7 @@ class AutoSyncSystem {
         // Listen for new tracking additions
         this.addEventListener('trackingAdded', (event) => {
             console.log('🔄 New tracking added');
-            this.handleNewTracking(event.detail);
+            this.createShipmentFromTracking(event.detail);
         });
 
         // Listen for tracking imports

--- a/pages/tracking/tracking-form-progressive.js
+++ b/pages/tracking/tracking-form-progressive.js
@@ -2449,7 +2449,12 @@ async function handleEnhancedSubmit(e) {
                     }
                     
                     // Dispatch event per notificare altri componenti
-                    window.dispatchEvent(new Event('trackingsUpdated'));
+                    window.dispatchEvent(new CustomEvent('trackingsUpdated', {
+                        detail: { trackings: [result.tracking], source: 'manual_add' }
+                    }));
+                    window.dispatchEvent(new CustomEvent('trackingAdded', {
+                        detail: result.tracking
+                    }));
                     
                     // Se ancora non funziona, ricarica la pagina
                     setTimeout(() => {
@@ -4486,22 +4491,23 @@ if (finalData.status === 'sailing' || finalData.status === 'SAILING') {
                try {
                    const savedTracking = await window.supabaseTrackingService.createTracking(finalData);
                    if (savedTracking) {
-                       return { success: true, message: 'Tracking salvato in Supabase!' };
+                       return { success: true, message: 'Tracking salvato in Supabase!', tracking: savedTracking };
                    }
                } catch (supabaseError) {
                    console.error('Errore salvataggio Supabase:', supabaseError);
                    // Continua con localStorage come fallback
                }
            }
-           
+
            // Fallback to localStorage
            const trackings = JSON.parse(localStorage.getItem('trackings') || '[]');
-           trackings.push({
+           const newTracking = {
                ...finalData,
                id: Date.now()
-           });
+           };
+           trackings.push(newTracking);
            localStorage.setItem('trackings', JSON.stringify(trackings));
-           return { success: true, message: 'Tracking aggiunto localmente' };
+           return { success: true, message: 'Tracking aggiunto localmente', tracking: newTracking };
        }
    }// ========================================
    // FILE IMPORT


### PR DESCRIPTION
## Summary
- emit a `trackingAdded` event with new tracking info
- return the new tracking data from `processEnhancedTracking`
- create shipments immediately on `trackingAdded`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686c1aaa1fb08324b1a4446799c2e985