### PR TITLE
Add auto-sync system integration

### DIFF
--- a/shipments.html
+++ b/shipments.html
@@ -51,6 +51,7 @@
     <script src="/core/products-link-filters-fix.js"></script>
     <script src="/core/reset-button-visibility-fix.js"></script>
    <script src="/core/simple-rollback-fix.js"></script>
+    <script type="module" src="/core/auto-sync-system.js"></script>
     <script src="/phase2-architecture.js"></script>
     <script src="/core/shipments-registry.js"></script>
     <script src="/pages/shipments/registry-core.js"></script>

--- a/tracking.html
+++ b/tracking.html
@@ -333,7 +333,8 @@
             TableManager: !!window.TableManager
         });
     </script>
-    
+    <script type="module" src="/core/auto-sync-system.js"></script>
+
     <!-- Legacy Scripts -->
     <script src="/core/auth.js"></script>
     <script src="/core/auth-init.js"></script>


### PR DESCRIPTION
## Summary
- include auto-sync system in tracking and shipments pages
- load the sync script before shipment modules
- start auto-sync after `shipmentsRegistryReady` event

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686c56da8cd48324aafc9e0a3e807ab3