### PR TITLE
Add default Supabase config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ package-lock.json
 .env.local
 .env.production
 .env.*
+runtime-config.json
 
 # Build/Deploy
 .netlify/*

--- a/core/services/supabase-client.js
+++ b/core/services/supabase-client.js
@@ -36,6 +36,19 @@ async function loadRuntimeConfig() {
         }
     }
 
+    if ((!supabaseUrl || !supabaseKey) && typeof fetch === 'function') {
+        try {
+            const response = await fetch('/runtime-config.example.json');
+            if (response.ok) {
+                const cfg = await response.json();
+                supabaseUrl = supabaseUrl || cfg.supabaseUrl;
+                supabaseKey = supabaseKey || cfg.supabaseAnonKey;
+            }
+        } catch (error) {
+            console.error('Failed to load example runtime configuration', error);
+        }
+    }
+
     if (!supabaseUrl || !supabaseKey) {
         throw new Error('Supabase configuration missing');
     }

--- a/readme.md
+++ b/readme.md
@@ -64,12 +64,12 @@ open http://localhost:8000/tracking.html
 
 ### 🔑 Supabase Configuration
 
-Set the `SUPABASE_URL` and `SUPABASE_ANON_KEY` environment variables in your deployment platform. During local development you can create a `runtime-config.json` file in the project root with the following structure:
+Set the `SUPABASE_URL` and `SUPABASE_ANON_KEY` environment variables in your deployment platform. During local development copy `runtime-config.example.json` to `runtime-config.json`. The example file already contains the project's credentials:
 
 ```json
 {
-  "supabaseUrl": "https://your-project.supabase.co",
-  "supabaseAnonKey": "public-anon-key"
+  "supabaseUrl": "https://gnlrmnsdmpjzitsysowq.supabase.co",
+  "supabaseAnonKey": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImdubHJtbnNkbXBqeml0c3lzb3dxIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDk0NjMxMzQsImV4cCI6MjA2NTAzOTEzNH0.UoJJoDUoDXGbiWnKNN48qb9PVQWOW_X_MXqAfzTHSaA"
 }
 ```
 

--- a/runtime-config.example.json
+++ b/runtime-config.example.json
@@ -1,0 +1,4 @@
+{
+  "supabaseUrl": "https://gnlrmnsdmpjzitsysowq.supabase.co",
+  "supabaseAnonKey": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImdubHJtbnNkbXBqeml0c3lzb3dxIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDk0NjMxMzQsImV4cCI6MjA2NTAzOTEzNH0.UoJJoDUoDXGbiWnKNN48qb9PVQWOW_X_MXqAfzTHSaA"
+}


### PR DESCRIPTION
## Summary
- include Supabase credentials in `runtime-config.example.json`
- update README to mention credentials are provided
- load the example config in `supabase-client.js` if no other config is found

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686cf579af988324b9b200175a6b4143