### PR TITLE
Remove legacy auth scripts

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -9,7 +9,7 @@
     <link rel="stylesheet" href="/assets/css/solarium.css">
     
     <!-- Core JS Modules -->
-    <script type="module" src="/core/auth-init.js"></script>
+    <script type="module" src="/core/services/supabase-client.js"></script>
     <script type="module" src="/core/api-client.js"></script>
     <script type="module" src="/core/header-component.js"></script>
     <script type="module" src="/core/notification-system.js"></script>

--- a/import.html
+++ b/import.html
@@ -21,6 +21,7 @@
     <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
     
     <!-- Core Modules - FIX: path relativi consistenti -->
+    <script type="module" src="/core/services/supabase-client.js"></script>
     <script type="module" src="/core/header-component.js"></script>
     <script type="module" src="/core/notification-system.js"></script>
     <script type="module" src="/core/modal-system.js"></script>

--- a/products.html
+++ b/products.html
@@ -15,6 +15,7 @@
     <link rel="stylesheet" href="/assets/css/solarium.css">
 
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+    <script type="module" src="/core/services/supabase-client.js"></script>
 
     <!-- Chart.js for Cost Analytics -->
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.js"></script>
@@ -51,8 +52,6 @@
     </script>
     
     <!-- STESSI Legacy Scripts -->
-    <script src="/core/auth.js"></script>
-    <script src="/core/auth-init.js"></script>
     
     <!-- Phase 2 Architecture -->
     <script src="/phase2-architecture.js"></script>

--- a/settings.html
+++ b/settings.html
@@ -12,6 +12,7 @@
     <link rel="stylesheet" href="/assets/css/solarium.css">
 
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+    <script type="module" src="/core/services/supabase-client.js"></script>
     
     <script type="module">
         // Import core modules IDENTICI a tracking.html
@@ -52,8 +53,6 @@
         })();
     </script>
 
-    <script src="/core/auth.js"></script>
-    <script src="/core/auth-init.js"></script>
     
     <script type="module">
         import authGuard from '/core/auth-guard.js';

--- a/shipments.html
+++ b/shipments.html
@@ -17,15 +17,16 @@
     <script src="https://cdn.jsdelivr.net/npm/papaparse@5.4.1/papaparse.min.js"></script>
     
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.js"></script>
+    <script type="module" src="/core/services/supabase-client.js"></script>
     
     <script type="module">
         // Import core modules IDENTICI a tracking.html
         import api from '/core/api-client.js';
+        import { supabase } from '/core/services/supabase-client.js';
         import headerComponent from '/core/header-component.js';
         import notificationSystem from '/core/notification-system.js';
         import modalSystem from '/core/modal-system.js';
         import organizationService from '/core/services/organization-service.js';
-        import { supabase } from '/core/services/supabase-client.js';
         import supabaseShipmentsService from '/core/services/supabase-shipments-service.js';
 
         // Make modules available globally
@@ -43,8 +44,6 @@
     
     <script src="/core/product-sync.js"></script>
 
-    <script src="/core/auth.js"></script>
-    <script src="/core/auth-init.js"></script>
     <script src="/core/import-manager.js"></script>
     <script src="/core/export-manager.js"></script>
     <script src="/core/product-linking-system-v20-1-final.js"></script>

--- a/test-integration.html
+++ b/test-integration.html
@@ -14,6 +14,7 @@
     <!-- Solarium CSS - STESSO path delle altre pagine -->
     <link rel="stylesheet" href="/assets/css/solarium.css">
     
+    <script type="module" src="/core/services/supabase-client.js"></script>
     <!-- Core Modules - IDENTICI alle altre pagine -->
     <script type="module">
         import api from '/core/api-client.js';
@@ -26,10 +27,6 @@
         window.NotificationSystem = notificationSystem;
         window.ModalSystem = modalSystem;
     </script>
-    
-    <!-- Legacy Scripts -->
-    <script src="/core/auth.js"></script>
-    <script src="/core/auth-init.js"></script>
     
     <!-- Phase 2 Architecture -->
     <script src="/phase2-architecture.js"></script>

--- a/tracking.html
+++ b/tracking.html
@@ -17,6 +17,7 @@
     
     <!-- Supabase -->
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+    <script type="module" src="/core/services/supabase-client.js"></script>
     
     <!-- Bootstrap JS for dropdowns -->
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
@@ -283,10 +284,10 @@
     <script type="module">
         // Import core modules
         import api from '/core/api-client.js';
+        import { supabase } from '/core/services/supabase-client.js';
         import headerComponent from '/core/header-component.js';
         import notificationSystem from '/core/notification-system.js';
         import modalSystem from '/core/modal-system.js';
-        import { supabase } from '/core/services/supabase-client.js';
         import supabaseTrackingService from '/core/services/supabase-tracking-service.js';
         import organizationApiKeysService from '/core/services/organization-api-keys-service.js';
         // Import ExportManager (might be a global or named export)
@@ -335,10 +336,6 @@
     </script>
     <script type="module" src="/core/auto-sync-system.js"></script>
 
-    <!-- Legacy Scripts -->
-    <script src="/core/auth.js"></script>
-    <script src="/core/auth-init.js"></script>
-    
     <!-- Load Export Manager (legacy) -->
     <script src="/core/export-manager.js"></script>
     


### PR DESCRIPTION
## Summary
- drop `auth.js` and `auth-init.js` from HTML pages
- load `supabase-client.js` before components requiring authentication
- reorder module imports so Supabase loads first

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d1a7b210c83248cbf62c0e2e91346