### PR TITLE
fix: expose supabase client globally

### DIFF
--- a/core/services/supabase-client.js
+++ b/core/services/supabase-client.js
@@ -70,6 +70,11 @@ export const supabase = createClient(supabaseUrl, supabaseKey, {
     }
 });
 
+if (typeof window !== 'undefined') {
+    window.supabase = supabase;
+    window.supabaseClient = supabase; // for legacy code
+}
+
 // --- Helper e Funzioni di Supporto (Il tuo codice originale, mantenuto) ---
 
 export const requireAuth = async () => {


### PR DESCRIPTION
## Summary
- assign `supabase` client to the global `window` object after creation

## Testing
- `nvm use 18`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d1e6194ac8324a25d54c852a9ed9a