### PR TITLE
Improve error for missing Supabase credentials

### DIFF
--- a/core/services/supabase-client.js
+++ b/core/services/supabase-client.js
@@ -50,7 +50,11 @@ async function loadRuntimeConfig() {
     }
 
     if (!supabaseUrl || !supabaseKey) {
-        throw new Error('Supabase configuration missing');
+        const message =
+            'Supabase credentials are not set. ' +
+            'Ensure SUPABASE_URL and SUPABASE_ANON_KEY are configured or copy ' +
+            'runtime-config.example.json to runtime-config.json.';
+        throw new Error(message);
     }
 }
 


### PR DESCRIPTION
## Summary
- provide more informative error message when Supabase credentials are missing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d1e6361cc83248e26ca5dcdf76e86