### PR TITLE
Initialize Supabase before auth access

### DIFF
--- a/core/header-component.js
+++ b/core/header-component.js
@@ -1,7 +1,7 @@
 // header-component.js - Header unificato con SINGLETON PATTERN ROBUSTO
 import api from '/core/api-client.js';
 import notificationSystem from '/core/notification-system.js';
-import { supabase } from '/core/services/supabase-client.js';
+import { supabase, initializeSupabase } from '/core/services/supabase-client.js';
 
 // SINGLETON PATTERN ROBUSTO
 let headerInstance = null;
@@ -77,6 +77,7 @@ export class HeaderComponent {
     }
     
     async _performInit() {
+        await initializeSupabase();
         console.log('🔧 [HeaderComponent] Starting initialization...');
         
         // CRITICAL: Rimuovi TUTTI gli header esistenti prima di inizializzare
@@ -98,7 +99,7 @@ export class HeaderComponent {
             await this.mount();
             console.log('✅ [HeaderComponent] Header mounted to DOM');
             
-            this.attachEventListeners();
+            await this.attachEventListeners();
             console.log('✅ [HeaderComponent] Event listeners attached');
             
             this.initialized = true;
@@ -280,7 +281,7 @@ export class HeaderComponent {
             this.updateUserDisplay(userInfo);
             
             // Re-attach event listeners nel caso siano stati persi
-            this.attachEventListeners();
+            await this.attachEventListeners();
             
             return;
         }
@@ -360,6 +361,7 @@ export class HeaderComponent {
         }
         
         try {
+            await initializeSupabase();
             if (supabase) {
                 const { data: { user } } = await supabase.auth.getUser();
                 
@@ -733,7 +735,8 @@ export class HeaderComponent {
         return window.location.pathname === href;
     }
     
-    attachEventListeners() {
+    async attachEventListeners() {
+        await initializeSupabase();
         // CRITICAL FIX: Previeni attach multipli di event listeners
         // Rimuovi vecchi listener prima di aggiungerne di nuovi
         

--- a/core/services/organization-service.js
+++ b/core/services/organization-service.js
@@ -1,4 +1,4 @@
-import { supabase } from '/core/services/supabase-client.js';
+import { supabase, initializeSupabase } from '/core/services/supabase-client.js';
 
 class OrganizationService {
     constructor() {
@@ -9,7 +9,9 @@ class OrganizationService {
 
     async init() {
         if (this.initialized) return;
-        
+
+        await initializeSupabase();
+
         try {
             const { data: { user } } = await supabase.auth.getUser();
             if (!user) throw new Error('No authenticated user');

--- a/core/services/supabase-tracking-service.js
+++ b/core/services/supabase-tracking-service.js
@@ -1,5 +1,5 @@
 // core/services/supabase-tracking-service.js
-import { supabase } from '/core/services/supabase-client.js';
+import { supabase, initializeSupabase } from '/core/services/supabase-client.js';
 
 class SupabaseTrackingService {
     constructor() {
@@ -320,6 +320,7 @@ class SupabaseTrackingService {
     // ========================================
 
     async getCurrentUser() {
+        await initializeSupabase();
         const { data: { user } } = await supabase.auth.getUser();
         return user;
     }

--- a/core/services/tracking-service.js
+++ b/core/services/tracking-service.js
@@ -4,7 +4,7 @@
 import supabaseTrackingService from '/core/services/supabase-tracking-service.js';
 import userSettingsService from '/core/services/user-settings-service.js';
 import organizationApiKeysService from '/core/services/organization-api-keys-service.js';
-import { supabase } from '/core/services/supabase-client.js';
+import { supabase, initializeSupabase } from '/core/services/supabase-client.js';
 
 class TrackingService {
     constructor() {
@@ -51,6 +51,7 @@ class TrackingService {
     }
 
     async _doInitialize() {
+        await initializeSupabase();
     try {
         if (this.debugMode) {
             console.group('🔧 [TrackingService] DETAILED INITIALIZATION');
@@ -123,6 +124,7 @@ return true;
 
     async testSupabaseConnection() {
         try {
+            await initializeSupabase();
             const { data: { user } } = await supabase.auth.getUser();
             return !!user;
         } catch (e) {
@@ -322,6 +324,8 @@ return true;
     // ... resto del codice rimane uguale ...
 
     async callShipsGoAPI(version, endpoint, method, params, data, contentType) {
+        await initializeSupabase();
+
         if (this.useSupabase) {
             // Usa Edge Function invece di chiamata diretta
             const { data: { user } } = await supabase.auth.getUser();


### PR DESCRIPTION
## Summary
- import `initializeSupabase` in services and header component
- ensure Supabase is initialized before any `supabase.auth` usage
- make header event binding async

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686fbca597988324aabb8ce9ed5f0f8a