### PR TITLE
Add shipments registry init on tracking page

### DIFF
--- a/tracking.html
+++ b/tracking.html
@@ -453,6 +453,8 @@ setTimeout(() => {
 
     <!-- Load Tracking Service -->
     <script type="module" src="/core/services/tracking-service.js"></script>
+    <!-- Shipments registry for unified tracking -->
+    <script src="shipments-initialization-fix.js"></script>
     <script src="/core/auto-sync-system.js"></script>
     
     <!-- Load Progressive Form -->


### PR DESCRIPTION
## Summary
- load `shipments-initialization-fix.js` on tracking page before `auto-sync-system.js`
- ensures the shipments registry and `shipmentsRegistryReady` event are available

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68700a20b0408324ae1f9ec2936cee22