### PR TITLE
Remove redundant tracking service script

### DIFF
--- a/tracking.html
+++ b/tracking.html
@@ -451,8 +451,6 @@ setTimeout(() => {
 }, 2000);
 </script>
 
-    <!-- Load Tracking Service -->
-    <script type="module" src="/core/services/tracking-service.js"></script>
     <!-- Shipments registry for unified tracking -->
     <script src="shipments-initialization-fix.js"></script>
     <script src="/core/auto-sync-system.js"></script>


### PR DESCRIPTION
## Summary
- avoid loading `tracking-service.js` twice in `tracking.html`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687012f79a208324ba95507230b9176c