### PR TITLE
Add Supabase init module

### DIFF
--- a/core/services/supabase-shipments-service.js
+++ b/core/services/supabase-shipments-service.js
@@ -1,4 +1,5 @@
 // core/services/supabase-shipments-service.js
+import '/core/supabase-init.js';
 import { supabase } from '/core/services/supabase-client.js';
 import { getActiveOrganizationId } from '/core/services/organization-service.js';
 

--- a/core/shipments-registry.js
+++ b/core/shipments-registry.js
@@ -1,6 +1,7 @@
 // shipments-registry.js - Enhanced Shipments Registry with Supabase support
 // Path: /core/shipments-registry.js
 import supabaseShipmentsService from '/core/services/supabase-shipments-service.js';
+import '/core/supabase-init.js';
 import { supabase } from '/core/services/supabase-client.js';
 import { getActiveOrganizationId } from '/core/services/organization-service.js';
 

--- a/core/supabase-init.js
+++ b/core/supabase-init.js
@@ -1,0 +1,3 @@
+import { initializeSupabase } from '/core/services/supabase-client.js';
+export const supabaseReady = initializeSupabase();
+export default supabaseReady;

--- a/login.html
+++ b/login.html
@@ -457,6 +457,7 @@
         <pre id="debugContent"></pre>
     </div>
     
+    <script type="module" src="/core/supabase-init.js"></script>
     <script type="module">
         import { supabase, initializeSupabase } from '/core/services/supabase-client.js';
 

--- a/pages/import/index.js
+++ b/pages/import/index.js
@@ -4,6 +4,7 @@
 // Import organization service
 import organizationService, { getActiveOrganizationId } from '/core/services/organization-service.js';
 import { importWizard } from '/core/import-wizard.js';
+import '/core/supabase-init.js';
 import { supabase } from '/core/services/supabase-client.js';
 importWizard.setSupabaseClient(supabase);
 import { showContextMenu } from '/core/components/context-menu.mjs';

--- a/pages/products/index.js
+++ b/pages/products/index.js
@@ -3,6 +3,7 @@
 // Import servizi necessari
 import organizationService, { getActiveOrganizationId } from '/core/services/organization-service.js';
 import { importWizard } from '/core/import-wizard.js';
+import '/core/supabase-init.js';
 import { supabase } from '/core/services/supabase-client.js';
 import TableManager from '/core/table-manager.js';
 window.supabase = supabase;

--- a/products.html
+++ b/products.html
@@ -71,9 +71,10 @@
 
     <!-- SortableJS for column drag/drop -->
     <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
-    
+
     <!-- Products page specific script -->
-<script type="module" src="/pages/products/index.js"></script>
+    <script type="module" src="/core/supabase-init.js"></script>
+    <script type="module" src="/pages/products/index.js"></script>
     
     <!-- Product Analytics Charts System -->
     <script src="/pages/products/product-analytics-charts.js"></script>

--- a/settings.html
+++ b/settings.html
@@ -13,6 +13,7 @@
     <link rel="stylesheet" href="/assets/css/solarium.css">
 
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+    <script type="module" src="/core/supabase-init.js"></script>
     
     <script type="module">
         // Import core modules IDENTICI a tracking.html

--- a/shipments.html
+++ b/shipments.html
@@ -59,6 +59,7 @@
    <script src="/core/simple-rollback-fix.js"></script>
     <script src="/phase2-architecture.js"></script>
     <script src="shipments-initialization-fix.js"></script>
+    <script type="module" src="/core/supabase-init.js"></script>
     <script type="module" src="/core/shipments-registry.js"></script>
     <script src="/core/auto-sync-system.js"></script>
     <script src="/pages/shipments/shipments-unified-mapping.js"></script>

--- a/tracking.html
+++ b/tracking.html
@@ -392,6 +392,7 @@ window.performanceReport = function() {
 };
 </script>
     <!-- Page Logic -->
+    <script type="module" src="/core/supabase-init.js"></script>
     <script type="module" src="/pages/tracking/index.js"></script>
     <!-- FIX: Assicura che showAddTrackingForm sia disponibile -->
 <script>


### PR DESCRIPTION
## Summary
- create `core/supabase-init.js` to initialize Supabase
- load the new module on pages using Supabase
- ensure modules using Supabase import the init module

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68701809ae888324868531d2e054439e