### PR TITLE
fix: expose trackingService globally

### DIFF
--- a/core/services/tracking-service.js
+++ b/core/services/tracking-service.js
@@ -1841,3 +1841,4 @@ if (window.location.hostname === 'localhost') {
 }
 
 export default trackingService;
+window.trackingService = trackingService;


### PR DESCRIPTION
## Summary
- expose `trackingService` on the `window` object

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687016d79f04832490189d25c16cd5a6