### PR TITLE
Expose global supabase client

### DIFF
--- a/core/services/supabase-client.js
+++ b/core/services/supabase-client.js
@@ -262,3 +262,8 @@ if (supabaseClient) {
 } else if (supabaseInitPromise) {
     supabaseInitPromise.then(setupAuthListener);
 }
+
+// Expose Supabase client globally when running in the browser
+if (typeof window !== 'undefined') {
+    window.supabaseClient = supabase;
+}


### PR DESCRIPTION
## Summary
- expose the `supabase` instance on `window.supabaseClient`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687015a05e608324a0d5d35fdced6263