### PR TITLE
Update dependency manager for ES modules

### DIFF
--- a/shipments-initialization-fix.js
+++ b/shipments-initialization-fix.js
@@ -25,7 +25,8 @@ class ShipmentsDependencyManager {
         this.dependencies.set('shipments-registry', {
             script: '/core/shipments-registry.js',
             global: 'ShipmentsRegistry',
-            dependencies: ['phase2-architecture']
+            dependencies: ['phase2-architecture'],
+            module: true
         });
         
         this.dependencies.set('documents-manager', {
@@ -140,7 +141,7 @@ class ShipmentsDependencyManager {
         console.log(`📥 Loading ${moduleName}...`);
         
         try {
-            await this.loadScript(module.script);
+            await this.loadScript(module.script, module.module);
             
             // Wait for global to be available
             const success = await this.waitForGlobal(module.global, 5000);
@@ -176,7 +177,7 @@ class ShipmentsDependencyManager {
         return obj !== undefined;
     }
     
-    async loadScript(src) {
+    async loadScript(src, isModule = false) {
         return new Promise((resolve, reject) => {
             // Check if script already exists
             const existing = document.querySelector(`script[src="${src}"]`);
@@ -184,9 +185,12 @@ class ShipmentsDependencyManager {
                 resolve();
                 return;
             }
-            
+
             const script = document.createElement('script');
             script.src = src;
+            if (isModule) {
+                script.type = 'module';
+            }
             script.onload = () => resolve();
             script.onerror = () => reject(new Error(`Failed to load script: ${src}`));
             document.head.appendChild(script);


### PR DESCRIPTION
## Summary
- support ES modules when loading shipments registry and similar
- add module flag for `shipments-registry`
- handle `type="module"` in `loadScript`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687016cf957c8324952dda21f6629bae