### PR TITLE
Remove redundant TableManager definitions

### DIFF
--- a/pages/products/index.js
+++ b/pages/products/index.js
@@ -5,6 +5,7 @@ import organizationService, { getActiveOrganizationId } from '/core/services/org
 import { importWizard } from '/core/import-wizard.js';
 import { supabase } from '/core/services/supabase-client.js';
 import TableManager from '/core/table-manager.js';
+window.TableManager = TableManager;
 window.supabase = supabase;
 importWizard.setSupabaseClient(supabase);
 console.log('[DEBUG] Supabase client in wizard:', window.importWizard.supabase);

--- a/products.html
+++ b/products.html
@@ -28,7 +28,6 @@
     import notificationSystem from '/core/notification-system.js';
     import modalSystem from '/core/modal-system.js';
     import organizationService from '/core/services/organization-service.js';
-    import TableManager from '/core/table-manager.js';
     
     // Make organization service available globally
     window.organizationService = organizationService;
@@ -37,18 +36,6 @@
         window.headerComponent = headerComponent;
         window.NotificationSystem = notificationSystem;
         window.ModalSystem = modalSystem;
-        window.TableManager = TableManager;
-
-        window.registerTableManager = function(id, instance) {
-            if (!window.tableManagers) {
-                window.tableManagers = {};
-            }
-            window.tableManagers[id] = instance;
-        };
-
-        window.getTableManager = function(id) {
-            return window.tableManagers?.[id];
-        };
     </script>
     
     <!-- STESSI Legacy Scripts -->


### PR DESCRIPTION
## Summary
- avoid redefining `TableManager` utilities in `products.html`
- expose `TableManager` globally from `pages/products/index.js`

## Testing
- `npm test` *(fails: Cannot find module '@supabase/supabase-js')*

------
https://chatgpt.com/codex/tasks/task_e_687017f7a8608324ba6d5af82d6b4ea6