### PR TITLE
Fix table manager initialization on tracking page

### DIFF
--- a/pages/tracking/index.js
+++ b/pages/tracking/index.js
@@ -1,5 +1,6 @@
 // index.js - Clean tracking page logic with all mappings
 import TableManager from '/core/table-manager.js';
+window.TableManager = TableManager;
 
 // State
 let trackings = [];

--- a/tracking.html
+++ b/tracking.html
@@ -293,9 +293,6 @@
         import organizationService, { getActiveOrganizationId } from '/core/services/organization-service.js';
         // Import ExportManager (might be a global or named export)
         // import ExportManager from '/core/export-manager.js';
-        import TableManager from '/core/table-manager.js';
-        import trackingService from '/core/services/tracking-service.js';
-        
         // Make modules available globally
         window.api = api;
         window.headerComponent = headerComponent;
@@ -307,19 +304,6 @@
         window.organizationService = organizationService;
         window.getActiveOrganizationId = getActiveOrganizationId;
         // window.ExportManager = ExportManager; // Commented out until we verify export structure
-        window.TableManager = TableManager;
-        
-        // Register table manager globally
-        window.registerTableManager = function(id, instance) {
-            if (!window.tableManagers) {
-                window.tableManagers = {};
-            }
-            window.tableManagers[id] = instance;
-        };
-        
-        window.getTableManager = function(id) {
-            return window.tableManagers?.[id];
-        };
         
         // Initialize components
         headerComponent.init();


### PR DESCRIPTION
## Summary
- rely on global table manager helpers
- expose `TableManager` globally for other modules
- remove unused tracking-service import

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687020832e40832497be8e9ebc6702e8