### PR TITLE
Fix tracking-service load order

### DIFF
--- a/tracking.html
+++ b/tracking.html
@@ -15,6 +15,9 @@
     <link rel="stylesheet" href="/core/modal-system.css">
     <link rel="stylesheet" href="/pages/tracking/tracking-complete.css">
     <link rel="stylesheet" href="/pages/tracking/tracking-table.css">
+
+    <!-- Tracking Service -->
+    <script type="module" src="/core/services/tracking-service.js"></script>
     
     <!-- Supabase -->
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>


### PR DESCRIPTION
## Summary
- ensure tracking-service loads before any dependent scripts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6870229609988324b2b40e7985720464