### PR TITLE
Fix tracking page script order

### DIFF
--- a/tracking.html
+++ b/tracking.html
@@ -17,6 +17,7 @@
     <link rel="stylesheet" href="/pages/tracking/tracking-table.css">
 
     <!-- Tracking Service -->
+    <script type="module" src="/core/services/supabase-client.js"></script>
     <script type="module" src="/core/services/tracking-service.js"></script>
     
     <!-- Supabase -->
@@ -380,7 +381,6 @@ window.performanceReport = function() {
 </script>
     <!-- Page Logic -->
     <script type="module" src="/core/supabase-init.js"></script>
-    <script type="module" src="/pages/tracking/index.js"></script>
     <!-- FIX: Assicura che showAddTrackingForm sia disponibile -->
 <script>
 // Fix per il timeout del progressive form
@@ -441,7 +441,9 @@ setTimeout(() => {
 
     <!-- Shipments registry for unified tracking -->
     <script src="shipments-initialization-fix.js"></script>
+    <script type="module" src="/core/shipments-registry.js"></script>
     <script src="/core/auto-sync-system.js"></script>
+    <script type="module" src="/pages/tracking/index.js"></script>
     
     <!-- Load Progressive Form -->
     <script src="/pages/tracking/tracking-form-progressive.js"></script>


### PR DESCRIPTION
## Summary
- ensure supabase and tracking services load first in `tracking.html`
- move main tracking page script after auto-sync system
- register shipments registry before auto-sync

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687025d4ba4083248a552f6423cdfed4