### PR TITLE
Organization selector UX improvements

### DIFF
--- a/core/header-component.js
+++ b/core/header-component.js
@@ -243,6 +243,13 @@ export class HeaderComponent {
             background: var(--sol-gray-50);
         }
 
+        .org-selector .org-single {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            padding: 0 0.75rem;
+        }
+
         .org-selector .sol-dropdown-item.active {
             background: var(--sol-primary-light);
         }
@@ -489,15 +496,30 @@ export class HeaderComponent {
             // Check 3: Verifica se abbiamo dati validi
             const currentOrg = window.organizationService.getCurrentOrg();
             const userOrgs = window.organizationService.getUserOrgs();
-            
-            // Non mostrare se non c'è org o se c'è solo 1 org
-            if (!currentOrg || !userOrgs || userOrgs.length <= 1) {
+
+            if (!currentOrg || !userOrgs) {
+                console.error('[Header] Organization data missing');
                 return '';
             }
+
+            // Se esiste una sola organizzazione, mostra comunque le info
+            if (userOrgs.length === 1) {
+                return `
+                    <div class="org-selector" id="orgSelector">
+                        <div class="org-single">
+                            <i class="fas fa-building"></i>
+                            <strong>${currentOrg.organizations?.name || 'Organization'}</strong>
+                            <small style="color: var(--sol-gray-600);">${currentOrg.role || ''}</small>
+                        </div>
+                    </div>
+                `;
+            }
+
+            // Solo ora renderizza il selector per più organizzazioni
             
             // Solo ora renderizza il selector
             return `
-                <div class="org-selector">
+                <div class="org-selector" id="orgSelector">
                     <button class="sol-btn sol-btn-glass" id="orgSelectorBtn" onclick="window.toggleOrgDropdown && window.toggleOrgDropdown(event)">
                         <i class="fas fa-building"></i>
                         <span class="hide-mobile">${currentOrg.organizations?.name || 'Organization'}</span>

--- a/shipments.html
+++ b/shipments.html
@@ -733,6 +733,17 @@
     100% { transform: scale(1); }
 }
 
+.org-warning {
+    background: var(--sol-warning-light);
+    border: 1px solid var(--sol-warning);
+    color: var(--sol-warning-dark, #856404);
+    padding: 1.5rem;
+    border-radius: var(--sol-radius-md);
+    text-align: center;
+    margin: 2rem;
+    font-weight: 600;
+}
+
     </style>
 </head>
 <body>
@@ -4574,7 +4585,22 @@ MSCU7654321,container,in_transit,MSC,MSC,TIGER,CNNBO,Ningbo,ITLIV,Livorno,SGSIN,
    
    (function() {
        console.log('🔧 Applying shipments initialization fixes...');
-       
+
+       const userOrgs = window.organizationService?.getUserOrgs?.() || [];
+       if (userOrgs.length === 0) {
+           console.error('[Shipments] User has no organizations');
+           const main = document.getElementById('mainContent');
+           if (main) {
+               main.innerHTML = `
+    <div class="org-warning">
+        Non sei membro di nessuna organizzazione. Contatta un amministratore per essere aggiunto.
+    </div>
+               `;
+           }
+           document.querySelectorAll('.sol-page-actions button').forEach(btn => btn.disabled = true);
+           return;
+       }
+
        // Wait for dependency resolution system
        let initAttempts = 0;
        const maxAttempts = 50; // 5 seconds maximum wait


### PR DESCRIPTION
## Summary
- show the active organization even when there is only one
- display a clear warning message if the user has no organizations
- disable functionality when no organization is available

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6870384994e08324a6e60ae371ffe144