### PR TITLE
fix: remove redundant supabase globals

### DIFF
--- a/pages/products/index.js
+++ b/pages/products/index.js
@@ -8,8 +8,6 @@ import { getSupabase } from '/core/services/supabase-client.js';
 import TableManager from '/core/table-manager.js';
 window.TableManager = TableManager;
 const supabase = getSupabase();
-window.supabase = supabase;
-window.TableManager = TableManager;
 if (supabase) {
     importWizard.setSupabaseClient(supabase);
     console.log('[DEBUG] Supabase client in wizard:', window.importWizard.supabase);

--- a/settings.html
+++ b/settings.html
@@ -37,7 +37,6 @@
                 
                 // Import Supabase client
                 const { supabase } = await import('/core/services/supabase-client.js');
-                window.supabase = supabase;
                 console.log('[Settings] ✅ Supabase loaded');
                 
                 // Import UserSettings service

--- a/tracking.html
+++ b/tracking.html
@@ -305,7 +305,6 @@
         window.headerComponent = headerComponent;
         window.NotificationSystem = notificationSystem;
         window.ModalSystem = modalSystem;
-        window.supabase = supabase;
         window.supabaseTrackingService = supabaseTrackingService;
         window.organizationApiKeysService = organizationApiKeysService;
         window.organizationService = organizationService;


### PR DESCRIPTION
## Summary
- avoid reassigning global `supabase` client
- keep global client from `supabase-client.js`

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68703bca04748324b787596b2f80cb63