### PR TITLE
Update organization handling

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -307,29 +307,7 @@ class Application {
 // Create singleton instance
 const app = new Application();
 // Organization switching functions
-window.toggleOrgDropdown = function(event) {
-    event.stopPropagation();
-    const dropdown = document.getElementById('orgDropdown');
-    if (dropdown) {
-        dropdown.style.display = dropdown.style.display === 'none' ? 'block' : 'none';
-    }
-};
 
-window.switchOrganization = async function(orgId) {
-    if (window.organizationService) {
-        await window.organizationService.switchOrg(orgId);
-    }
-};
-
-// Close org dropdown on outside click
-document.addEventListener('click', (e) => {
-    if (!e.target.closest('.org-selector')) {
-        const orgDropdown = document.getElementById('orgDropdown');
-        if (orgDropdown) {
-            orgDropdown.style.display = 'none';
-        }
-    }
-});
 
 // Export singleton
 export default app;

--- a/core/auto-sync-system.js
+++ b/core/auto-sync-system.js
@@ -320,9 +320,9 @@ class AutoSyncSystem {
         if (window.shipmentsRegistry?.createShipment) {
             let userId = null;
             try {
-                const orgId = window.getActiveOrganizationId?.();
+                const orgId = window.currentOrganizationId;
                 if (!orgId) {
-                    throw new Error("Organization ID non trovato! L'utente non ha selezionato alcuna organizzazione.");
+                    throw new Error("Nessuna organizzazione trovata. Contatta un amministratore.");
                 }
 
                 const sb = window.supabase || (typeof supabase !== 'undefined' ? supabase : null);

--- a/core/import-wizard.js
+++ b/core/import-wizard.js
@@ -3,7 +3,7 @@ import notificationSystem from '/core/notification-system.js';
 import modalSystem from '/core/modal-system.js';
 import apiClient from '/core/api-client.js';
 import { supabase } from '/core/services/supabase-client.js';
-import { getActiveOrganizationId, ensureOrganizationSelected } from '/core/services/organization-service.js';
+import { getMyOrganizationId } from '/core/services/organization-service.js';
 
 class ImportWizard {
     constructor() {
@@ -768,10 +768,12 @@ if (!this.targetFields || !Array.isArray(this.targetFields) || this.targetFields
 
     try {
         // 1. Organization e User ID
-        if (!ensureOrganizationSelected()) {
-            throw new Error('Organization non selezionata!');
+        let orgId;
+        try {
+            orgId = await getMyOrganizationId(supabase);
+        } catch (e) {
+            throw new Error('Nessuna organizzazione trovata. Contatta un amministratore.');
         }
-        const orgId = getActiveOrganizationId();
         
         let supa = this.supabase || supabase || window.supabase;
         if (!supa || !supa.auth) {
@@ -1128,11 +1130,13 @@ gotoStep = (stepIndex) => {
 
 startImport = async () => {
     try {
-        if (!ensureOrganizationSelected()) {
-            notificationSystem.show("Missing organization context. Cannot proceed with import.", "error");
+        let orgId;
+        try {
+            orgId = await getMyOrganizationId(supabase);
+        } catch (e) {
+            notificationSystem.show("Nessuna organizzazione trovata. Contatta un amministratore.", "error");
             return;
         }
-        const orgId = getActiveOrganizationId();
         let supa = this.supabase || supabase || window.supabase;
         if (!supa || !supa.auth) {
             console.error('Supabase client not initialized');

--- a/core/services/organization-service.js
+++ b/core/services/organization-service.js
@@ -1,147 +1,20 @@
-import { getSupabase, initializeSupabase } from '/core/services/supabase-client.js';
-
-class OrganizationService {
-    constructor() {
-        this.currentOrg = null;
-        this.userOrgs = [];
-        this.initialized = false;
+export async function getMyOrganizationId(supabase) {
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) {
+        throw new Error('User not authenticated');
     }
-
-    async init() {
-        if (this.initialized) return;
-
-        await initializeSupabase();
-        const supabase = getSupabase();
-        if (!supabase) {
-            console.error('Supabase client non disponibile');
-            return;
-        }
-
-        try {
-            const { data: { user } } = await supabase.auth.getUser();
-            if (!user) throw new Error('No authenticated user');
-            
-            // Get user's organizations
-            const { data: memberships } = await supabase
-                .from('organization_members')
-                .select(`
-                    organization_id,
-                    role,
-                    organizations (
-                        id,
-                        name,
-                        slug,
-                        settings
-                    )
-                `)
-                .eq('user_id', user.id);
-            
-            if (memberships && memberships.length > 0) {
-                this.userOrgs = memberships;
-                
-                // Get saved preference or use first org
-                const savedOrgId = localStorage.getItem('currentOrganizationId');
-                const savedOrg = memberships.find(m => m.organization_id === savedOrgId);
-                
-                this.currentOrg = savedOrg || memberships[0];
-                this.savePreference();
-                
-                console.log('[OrganizationService] Initialized with org:', this.currentOrg.organizations.name);
-            } else {
-                console.warn('[OrganizationService] User has no organizations');
-            }
-            
-            this.initialized = true;
-            
-        } catch (error) {
-            console.error('[OrganizationService] Init error:', error);
-            // Per development, usa mock
-            this.currentOrg = {
-                organization_id: 'dev-org',
-                role: 'owner',
-                organizations: {
-                    id: 'dev-org',
-                    name: 'Development Org',
-                    slug: 'dev'
-                }
-            };
-        }
+    const { data, error } = await supabase
+        .from('organization_members')
+        .select('organization_id')
+        .eq('user_id', user.id)
+        .limit(1);
+    if (error) {
+        throw error;
     }
-
-    getCurrentOrgId() {
-        return this.currentOrg?.organization_id;
+    if (!data || data.length === 0) {
+        throw new Error('No organization found');
     }
-
-    getCurrentOrg() {
-        return this.currentOrg;
-    }
-
-    getUserOrgs() {
-        return this.userOrgs;
-    }
-
-    async switchOrg(orgId) {
-        const org = this.userOrgs.find(m => m.organization_id === orgId);
-        if (!org) throw new Error('Organization not found');
-        
-        this.currentOrg = org;
-        this.savePreference();
-        
-        // Emit event
-        window.dispatchEvent(new CustomEvent('organizationChanged', {
-            detail: { organization: org }
-        }));
-        
-        // Reload to refresh data
-        window.location.reload();
-    }
-
-    savePreference() {
-        if (this.currentOrg) {
-            localStorage.setItem('currentOrganizationId', this.currentOrg.organization_id);
-        }
-    }
-
-    hasPermission(requiredRole) {
-        if (!this.currentOrg) return false;
-        
-        const roleHierarchy = {
-            'owner': 3,
-            'admin': 2,
-            'member': 1,
-            'viewer': 0
-        };
-        
-        const userLevel = roleHierarchy[this.currentOrg.role] || 0;
-        const requiredLevel = roleHierarchy[requiredRole] || 0;
-        
-        return userLevel >= requiredLevel;
-    }
+    return data[0].organization_id;
 }
 
-// Singleton
-export const organizationService = new OrganizationService();
-
-export const getActiveOrganizationId = () => organizationService.getCurrentOrgId();
-
-export function ensureOrganizationSelected() {
-    const id = typeof getActiveOrganizationId === 'function'
-        ? getActiveOrganizationId()
-        : window.activeOrganizationId || null;
-    if (!id) {
-        alert("\u26A0\uFE0F Nessuna organizzazione selezionata! Selezionala dal menu.");
-        return false;
-    }
-    return true;
-}
-
-// Auto-init
-if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', () => {
-        setTimeout(() => organizationService.init(), 1000);
-    });
-} else {
-    setTimeout(() => organizationService.init(), 1000);
-}
-
-export default organizationService;
+export default { getMyOrganizationId };

--- a/core/services/supabase-shipments-service.js
+++ b/core/services/supabase-shipments-service.js
@@ -1,7 +1,7 @@
 // core/services/supabase-shipments-service.js
 import '/core/supabase-init.js';
 import { getSupabase } from '/core/services/supabase-client.js';
-import { getActiveOrganizationId, ensureOrganizationSelected } from '/core/services/organization-service.js';
+import { getMyOrganizationId } from '/core/services/organization-service.js';
 
 class SupabaseShipmentsService {
     constructor() {
@@ -10,12 +10,15 @@ class SupabaseShipmentsService {
 
     async getAllShipments() {
         try {
-            if (!ensureOrganizationSelected()) {
-                return [];
-            }
-            const orgId = getActiveOrganizationId();
             const supabase = getSupabase();
             if (!supabase) {
+                return [];
+            }
+            let orgId;
+            try {
+                orgId = await getMyOrganizationId(supabase);
+            } catch (e) {
+                console.error('Organization ID not found', e);
                 return [];
             }
             const query = supabase
@@ -61,14 +64,16 @@ class SupabaseShipmentsService {
         let orgId = null;
         let userId = null;
         try {
-            if (!ensureOrganizationSelected()) {
-                return null;
-            }
             const supabase = getSupabase();
             if (!supabase) {
                 return null;
             }
-            orgId = getActiveOrganizationId();
+            try {
+                orgId = await getMyOrganizationId(supabase);
+            } catch (e) {
+                console.error('Organization ID not found', e);
+                return null;
+            }
 
             const {
                 data: { user }
@@ -151,14 +156,17 @@ class SupabaseShipmentsService {
 
     async updateShipment(id, updates) {
         try {
-            if (!ensureOrganizationSelected()) {
-                return null;
-            }
             const supabase = getSupabase();
             if (!supabase) {
                 return null;
             }
-            const orgId = getActiveOrganizationId();
+            let orgId;
+            try {
+                orgId = await getMyOrganizationId(supabase);
+            } catch (e) {
+                console.error('Organization ID not found', e);
+                return null;
+            }
             const payload = this.preparePayload({
                 ...updates,
                 organization_id: orgId,

--- a/core/services/supabase-tracking-service.js
+++ b/core/services/supabase-tracking-service.js
@@ -1,6 +1,6 @@
 // core/services/supabase-tracking-service.js
 import { getSupabase, initializeSupabase } from '/core/services/supabase-client.js';
-import { getActiveOrganizationId, ensureOrganizationSelected } from '/core/services/organization-service.js';
+import { getMyOrganizationId } from '/core/services/organization-service.js';
 
 class SupabaseTrackingService {
     constructor() {
@@ -82,10 +82,12 @@ class SupabaseTrackingService {
             const user = await this.getCurrentUser();
             if (!user) throw new Error('User not authenticated');
 
-            if (!ensureOrganizationSelected()) {
+            let orgId;
+            try {
+                orgId = await getMyOrganizationId(getSupabase());
+            } catch (e) {
                 throw new Error('Organization ID missing');
             }
-            const orgId = getActiveOrganizationId?.() || (window.getActiveOrganizationId?.());
 
             // Prepara i dati per Supabase
             const supabaseData = this.prepareForSupabase(trackingData, user.id, orgId);
@@ -448,10 +450,12 @@ class SupabaseTrackingService {
             if (!user) {
                 throw new Error('User must be authenticated to migrate data');
             }
-            if (!ensureOrganizationSelected()) {
+            let orgId;
+            try {
+                orgId = await getMyOrganizationId(getSupabase());
+            } catch (e) {
                 throw new Error('Organization ID missing');
             }
-            const orgId = getActiveOrganizationId?.() || (window.getActiveOrganizationId?.());
 
             const localTrackings = this.getLocalStorageFallback();
             if (localTrackings.length === 0) {

--- a/pages/import/index.js
+++ b/pages/import/index.js
@@ -2,7 +2,7 @@
 // Phase 2: Revolutionary Business Intelligence Platform
 
 // Import organization service
-import organizationService, { getActiveOrganizationId, ensureOrganizationSelected } from '/core/services/organization-service.js';
+import { getMyOrganizationId } from '/core/services/organization-service.js';
 import { importWizard } from '/core/import-wizard.js';
 import '/core/supabase-init.js';
 import { supabase } from '/core/services/supabase-client.js';
@@ -42,14 +42,14 @@ async init() {
     console.log('[ProductIntelligence] Initializing system...');
     try {
         // 1. Inizializza i servizi e ottieni l'ID dell'organizzazione
-        if (window.organizationService && !window.organizationService.initialized) {
-            await window.organizationService.init();
+        let orgId;
+        try {
+            orgId = await getMyOrganizationId(supabase);
+        } catch (e) {
+            this.showStatus('Nessuna organizzazione trovata. Contatta un amministratore.', 'error');
+            return;
         }
-        if (!ensureOrganizationSelected()) {
-            this.showStatus('Organization data not available. Cannot load products.', 'warning');
-            return; // Interrompe l'esecuzione se non c'è un'organizzazione
-        }
-        this.organizationId = getActiveOrganizationId();
+        this.organizationId = orgId;
         console.log(`[ProductIntelligence] Using organization: ${this.organizationId}`);
 
         // 2. Carica i dati e genera le analytics

--- a/pages/products/index.js
+++ b/pages/products/index.js
@@ -1,7 +1,7 @@
 // pages/products/index.js — Product Intelligence System (NO tracking/spedizioni)
 
 // Import servizi necessari
-import organizationService, { getActiveOrganizationId, ensureOrganizationSelected } from '/core/services/organization-service.js';
+import { getMyOrganizationId } from '/core/services/organization-service.js';
 import { importWizard } from '/core/import-wizard.js';
 import '/core/supabase-init.js';
 import { getSupabase } from '/core/services/supabase-client.js';
@@ -202,14 +202,14 @@ showStatus(message, type = 'info', duration = 3000) {
     async init() {
         console.log('[ProductIntelligence] Initializing system...');
         try {
-            if (window.organizationService && !window.organizationService.initialized) {
-                await window.organizationService.init();
-            }
-            if (!ensureOrganizationSelected()) {
-                this.showStatus('Organization data not available. Cannot load products.', 'warning');
+            let orgId;
+            try {
+                orgId = await getMyOrganizationId(supabase);
+            } catch (e) {
+                this.showStatus('Nessuna organizzazione trovata. Contatta un amministratore.', 'error');
                 return;
             }
-            this.organizationId = getActiveOrganizationId();
+            this.organizationId = orgId;
             console.log(`[ProductIntelligence] Using organization: ${this.organizationId}`);
             await this.loadData();
             await this.generateAnalytics();

--- a/pages/shipments/shipments-details.js
+++ b/pages/shipments/shipments-details.js
@@ -821,9 +821,12 @@ if (window.ShipmentDetails) {
         
         async createShipment() {
             try {
-                const orgId = window.getActiveOrganizationId?.();
-                if (!orgId) {
-                    throw new Error("Organization ID non trovato! L'utente non ha selezionato alcuna organizzazione.");
+                const supabase = window.supabase;
+                let orgId;
+                try {
+                    orgId = await window.getMyOrganizationId ? await window.getMyOrganizationId(supabase) : null;
+                } catch (e) {
+                    throw new Error("Nessuna organizzazione trovata. Contatta un amministratore.");
                 }
                 const shipmentData = {
                     organization_id: orgId

--- a/products.html
+++ b/products.html
@@ -27,14 +27,12 @@
     import headerComponent from '/core/header-component.js';
     import notificationSystem from '/core/notification-system.js';
     import modalSystem from '/core/modal-system.js';
-    import organizationService, { ensureOrganizationSelected } from '/core/services/organization-service.js';
-
-    if (!ensureOrganizationSelected()) {
-        throw new Error('Organization not selected');
-    }
+    import { getMyOrganizationId } from '/core/services/organization-service.js';
+    const orgId = await getMyOrganizationId(supabase);
     
     // Make organization service available globally
-    window.organizationService = organizationService;
+    window.getMyOrganizationId = getMyOrganizationId;
+    window.currentOrganizationId = orgId;
         // Make modules available globally for backward compatibility
         window.api = api;
         window.headerComponent = headerComponent;

--- a/shipments.html
+++ b/shipments.html
@@ -25,18 +25,16 @@
         import headerComponent from '/core/header-component.js';
         import notificationSystem from '/core/notification-system.js';
         import modalSystem from '/core/modal-system.js';
-        import organizationService, { getActiveOrganizationId, ensureOrganizationSelected } from '/core/services/organization-service.js';
-        if (!ensureOrganizationSelected()) {
-            throw new Error('Organization not selected');
-        }
+        import { getMyOrganizationId } from '/core/services/organization-service.js';
+        const orgId = await getMyOrganizationId(supabase);
         
         // Make modules available globally
         window.api = api;
         window.headerComponent = headerComponent;
         window.NotificationSystem = notificationSystem;
         window.ModalSystem = modalSystem;
-        window.organizationService = organizationService;
-        window.getActiveOrganizationId = getActiveOrganizationId;
+        window.getMyOrganizationId = getMyOrganizationId;
+        window.currentOrganizationId = orgId;
     </script>
     
     <script src="/core/product-sync.js"></script>
@@ -2934,7 +2932,7 @@ function generateComprehensiveSampleData() {
                 id: `SHIP-2024-${String(Date.now() + i).slice(-6)}`,
                 shipmentNumber: `${carrier.code}${String(Math.floor(Math.random() * 9000000) + 1000000)}`,
                 type: type,
-                organization_id: window.getActiveOrganizationId ? window.getActiveOrganizationId() : null,
+                organization_id: window.currentOrganizationId || null,
                 carrier: carrier,
                 route: {
                     ...route,
@@ -3062,7 +3060,7 @@ async function ensureSampleData() {
                window.shipmentsRegistry = new window.ShipmentsRegistry();
                await window.shipmentsRegistry.init();
 
-               const orgId = window.getActiveOrganizationId ? window.getActiveOrganizationId() : null;
+               const orgId = window.currentOrganizationId;
                if (orgId) {
                    window.shipmentsRegistry.shipments = window.shipmentsRegistry.shipments.filter(s => s.organization_id === orgId);
                }
@@ -4586,20 +4584,19 @@ MSCU7654321,container,in_transit,MSC,MSC,TIGER,CNNBO,Ningbo,ITLIV,Livorno,SGSIN,
    (function() {
        console.log('🔧 Applying shipments initialization fixes...');
 
-       const userOrgs = window.organizationService?.getUserOrgs?.() || [];
-       if (userOrgs.length === 0) {
-           console.error('[Shipments] User has no organizations');
-           const main = document.getElementById('mainContent');
-           if (main) {
-               main.innerHTML = `
+      if (!window.currentOrganizationId) {
+          console.error('[Shipments] No organization available');
+          const main = document.getElementById('mainContent');
+          if (main) {
+              main.innerHTML = `
     <div class="org-warning">
-        Non sei membro di nessuna organizzazione. Contatta un amministratore per essere aggiunto.
+        Nessuna organizzazione trovata. Contatta un amministratore.
     </div>
-               `;
-           }
-           document.querySelectorAll('.sol-page-actions button').forEach(btn => btn.disabled = true);
-           return;
-       }
+              `;
+          }
+          document.querySelectorAll('.sol-page-actions button').forEach(btn => btn.disabled = true);
+          return;
+      }
 
        // Wait for dependency resolution system
        let initAttempts = 0;

--- a/tracking.html
+++ b/tracking.html
@@ -294,10 +294,8 @@
         import { supabase } from '/core/services/supabase-client.js';
         import supabaseTrackingService from '/core/services/supabase-tracking-service.js';
         import organizationApiKeysService from '/core/services/organization-api-keys-service.js';
-        import organizationService, { getActiveOrganizationId, ensureOrganizationSelected } from '/core/services/organization-service.js';
-        if (!ensureOrganizationSelected()) {
-            throw new Error('Organization not selected');
-        }
+        import { getMyOrganizationId } from '/core/services/organization-service.js';
+        const orgId = await getMyOrganizationId(supabase);
         // Import ExportManager (might be a global or named export)
         // import ExportManager from '/core/export-manager.js';
         // Make modules available globally
@@ -307,8 +305,8 @@
         window.ModalSystem = modalSystem;
         window.supabaseTrackingService = supabaseTrackingService;
         window.organizationApiKeysService = organizationApiKeysService;
-        window.organizationService = organizationService;
-        window.getActiveOrganizationId = getActiveOrganizationId;
+        window.getMyOrganizationId = getMyOrganizationId;
+        window.currentOrganizationId = orgId;
         // window.ExportManager = ExportManager; // Commented out until we verify export structure
         
         // Initialize components


### PR DESCRIPTION
## Summary
- introduce a lightweight organization service
- fetch organization info directly in the header
- simplify shipments and tracking services
- drop organization selection UI and related helpers
- display an error message when no organization is found

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687043616e008324a554dc7c2cfff76f