### PR TITLE
Add shipments RLS policies

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -152,6 +152,14 @@ Inside `supabase/security-fixes.sql` you will find additional validation queries
 Run the SQL in `supabase/shipments_carrier_columns.sql` using the Supabase SQL editor. This adds carrier
 information fields to `public.shipments` and grants the API role permission to insert or update them.
 
+### 🛡️ Shipments access policies
+
+Execute the statements in `supabase/shipments_access_policies.sql` to enable row-level
+security on shipments. The policy **"Org members can access own shipments"**
+restricts reads to members of the same organization. The file also creates
+analogous policies for `INSERT`, `UPDATE` and `DELETE` so organization members can
+manage only their own shipments.
+
 ## 🯩 Browser extension
 
 This repository does not include Chrome extension files like `background.js` or `content.js`. If you encounter errors referencing these scripts, they originate from an optional browser add-on maintained separately from **SCS Hub Pro**.

--- a/supabase/shipments_access_policies.sql
+++ b/supabase/shipments_access_policies.sql
@@ -1,0 +1,50 @@
+-- ==============================================
+-- SHIPMENTS ACCESS POLICIES
+-- ==============================================
+-- Run these statements in the Supabase SQL editor
+
+-- Allow organization members to read their own shipments
+DROP POLICY IF EXISTS "Org members can access own shipments" ON public.shipments;
+CREATE POLICY "Org members can access own shipments" ON public.shipments
+    FOR SELECT
+    USING (
+        organization_id IN (
+            SELECT organization_id
+            FROM organization_members
+            WHERE user_id = auth.uid()
+        )
+    );
+
+-- Analogous policies for other operations
+DROP POLICY IF EXISTS "Org members can insert shipments" ON public.shipments;
+CREATE POLICY "Org members can insert shipments" ON public.shipments
+    FOR INSERT
+    WITH CHECK (
+        organization_id IN (
+            SELECT organization_id
+            FROM organization_members
+            WHERE user_id = auth.uid()
+        )
+    );
+
+DROP POLICY IF EXISTS "Org members can update shipments" ON public.shipments;
+CREATE POLICY "Org members can update shipments" ON public.shipments
+    FOR UPDATE
+    USING (
+        organization_id IN (
+            SELECT organization_id
+            FROM organization_members
+            WHERE user_id = auth.uid()
+        )
+    );
+
+DROP POLICY IF EXISTS "Org members can delete shipments" ON public.shipments;
+CREATE POLICY "Org members can delete shipments" ON public.shipments
+    FOR DELETE
+    USING (
+        organization_id IN (
+            SELECT organization_id
+            FROM organization_members
+            WHERE user_id = auth.uid()
+        )
+    );


### PR DESCRIPTION
## Summary
- add RLS policies so organization members can act on their shipments
- document shipments access policies

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68704366054083248331bee25b2248c0