### PR TITLE
Handle supabaseReady rejection

### DIFF
--- a/core/services/supabase-tracking-service.js
+++ b/core/services/supabase-tracking-service.js
@@ -16,7 +16,12 @@ class SupabaseTrackingService {
         try {
             // Wait for Supabase and valid session before proceeding
             console.log('🔄 Waiting for Supabase and session...');
-            await window.supabaseReady;
+            try {
+                await window.supabaseReady;
+            } catch (err) {
+                console.error('❌ Supabase initialization failed:', err);
+                return this.getLocalStorageFallback();
+            }
             
             const supabase = getSupabase();
             if (!supabase) {
@@ -65,7 +70,12 @@ class SupabaseTrackingService {
     async getTracking(id) {
         try {
             // Wait for Supabase and valid session before proceeding
-            await window.supabaseReady;
+            try {
+                await window.supabaseReady;
+            } catch (err) {
+                console.error('❌ Supabase initialization failed:', err);
+                return this.getLocalStorageFallback();
+            }
             
             const supabase = getSupabase();
             if (!supabase) {
@@ -109,7 +119,12 @@ class SupabaseTrackingService {
     async createTracking(trackingData) {
         try {
             // Wait for Supabase and valid session before proceeding
-            await window.supabaseReady;
+            try {
+                await window.supabaseReady;
+            } catch (err) {
+                console.error('❌ Supabase initialization failed:', err);
+                return this.getLocalStorageFallback();
+            }
             
             // Protect against null/undefined trackingData
             if (!trackingData || typeof trackingData !== 'object') {


### PR DESCRIPTION
## Summary
- guard supabaseReady in tracking service methods
- fallback to local storage when initialization fails

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687163b10ca48324935e909352c3f926