### PR TITLE
Apply chart cleanup before creation

### DIFF
--- a/pages/dashboard/index.js
+++ b/pages/dashboard/index.js
@@ -156,9 +156,8 @@ class DashboardController {
         const ctx = document.getElementById('revenueChart');
         
         // Distruggi chart esistente
-        if (this.charts.revenue) {
-            this.charts.revenue.destroy();
-        }
+        const existing = Chart.getChart(ctx);
+        if (existing) existing.destroy();
 
         // Prepara dati
         const labels = dailyData.map(d => this.formatDate(d.date));
@@ -257,9 +256,8 @@ class DashboardController {
         const ctx = document.getElementById('statusChart');
         
         // Distruggi chart esistente
-        if (this.charts.status) {
-            this.charts.status.destroy();
-        }
+        const existing = Chart.getChart(ctx);
+        if (existing) existing.destroy();
 
         // Prepara dati
         const labels = Object.keys(statusData);

--- a/pages/products/product-analytics-charts.js
+++ b/pages/products/product-analytics-charts.js
@@ -63,11 +63,10 @@ class ProductAnalyticsCharts {
         if (!canvas) return;
         
         const ctx = canvas.getContext('2d');
-        
+
         // Destroy existing chart
-        if (this.charts.costTrends) {
-            this.charts.costTrends.destroy();
-        }
+        const existing = Chart.getChart(canvas);
+        if (existing) existing.destroy();
         
         // Get product intelligence system
         const productSystem = window.productIntelligenceSystem;
@@ -196,11 +195,10 @@ class ProductAnalyticsCharts {
         if (!canvas) return;
         
         const ctx = canvas.getContext('2d');
-        
+
         // Destroy existing chart
-        if (this.charts.costBreakdown) {
-            this.charts.costBreakdown.destroy();
-        }
+        const existing = Chart.getChart(canvas);
+        if (existing) existing.destroy();
         
         // Sample cost breakdown data
         const breakdownData = {

--- a/pages/shipments/carrier-performance.js
+++ b/pages/shipments/carrier-performance.js
@@ -685,9 +685,8 @@ class CarrierPerformanceAnalytics {
         if (!ctx) return;
         
         // Destroy existing chart
-        if (this.charts[canvasId]) {
-            this.charts[canvasId].destroy();
-        }
+        const existing = Chart.getChart(canvas);
+        if (existing) existing.destroy();
         
         const carriers = this.performanceMetrics.carriers.slice(0, 10);
         
@@ -732,9 +731,8 @@ class CarrierPerformanceAnalytics {
         if (!ctx) return;
         
         // Destroy existing chart
-        if (this.charts[canvasId]) {
-            this.charts[canvasId].destroy();
-        }
+        const existing = Chart.getChart(canvas);
+        if (existing) existing.destroy();
         
         const routes = this.performanceMetrics.routes.slice(0, 15);
         

--- a/pages/shipments/cost-allocation.js
+++ b/pages/shipments/cost-allocation.js
@@ -104,8 +104,9 @@ class CostAllocationUI {
         const canvas = document.getElementById('costBreakdownChart');
         if (!canvas) return;
         
-        if (canvas && this.chartInstance) {
-            this.chartInstance.destroy();
+        if (canvas) {
+            const existing = Chart.getChart(canvas);
+            if (existing) existing.destroy();
             this.chartInstance = null;
         }
         

--- a/pages/shipments/executive-bi-dashboard.js
+++ b/pages/shipments/executive-bi-dashboard.js
@@ -1346,11 +1346,10 @@ class ExecutiveBIDashboard {
         if (!canvas) return;
         
         const ctx = canvas.getContext('2d');
-        
+
         // Destroy existing chart if present
-        if (this.charts.volumeCostTrend) {
-            this.charts.volumeCostTrend.destroy();
-        }
+        const existing = Chart.getChart(canvas);
+        if (existing) existing.destroy();
         
         // Dati di esempio
         const labels = ['Gen', 'Feb', 'Mar', 'Apr', 'Mag', 'Giu', 'Lug', 'Ago', 'Set', 'Ott', 'Nov', 'Dic'];
@@ -1412,11 +1411,10 @@ class ExecutiveBIDashboard {
         if (!canvas) return;
         
         const ctx = canvas.getContext('2d');
-        
+
         // Destroy existing chart if present
-        if (this.charts.costStructure) {
-            this.charts.costStructure.destroy();
-        }
+        const existing = Chart.getChart(canvas);
+        if (existing) existing.destroy();
         
         this.charts.costStructure = new Chart(ctx, {
             type: 'doughnut',
@@ -1450,11 +1448,10 @@ class ExecutiveBIDashboard {
         if (!canvas) return;
         
         const ctx = canvas.getContext('2d');
-        
+
         // Destroy existing chart if present
-        if (this.charts.carrierPerformance) {
-            this.charts.carrierPerformance.destroy();
-        }
+        const existing = Chart.getChart(canvas);
+        if (existing) existing.destroy();
         
         this.charts.carrierPerformance = new Chart(ctx, {
             type: 'scatter',

--- a/pages/shipments/shipments-analytics.js
+++ b/pages/shipments/shipments-analytics.js
@@ -330,9 +330,8 @@ class ShipmentsAnalyticsEngine {
         if (!ctx) return;
         
         // Destroy existing chart
-        if (this.charts[canvasId]) {
-            this.charts[canvasId].destroy();
-        }
+        const existing = Chart.getChart(ctx);
+        if (existing) existing.destroy();
         
         this.charts[canvasId] = new Chart(ctx, {
             type: 'bar',
@@ -374,9 +373,8 @@ class ShipmentsAnalyticsEngine {
         if (!ctx) return;
         
         // Destroy existing chart
-        if (this.charts[canvasId]) {
-            this.charts[canvasId].destroy();
-        }
+        const existing = Chart.getChart(ctx);
+        if (existing) existing.destroy();
         
         const labels = Object.keys(costAnalysis.breakdown);
         const data = labels.map(l => costAnalysis.breakdown[l]);
@@ -427,9 +425,8 @@ class ShipmentsAnalyticsEngine {
         if (!ctx) return;
         
         // Destroy existing chart
-        if (this.charts[canvasId]) {
-            this.charts[canvasId].destroy();
-        }
+        const existing = Chart.getChart(ctx);
+        if (existing) existing.destroy();
         
         this.charts[canvasId] = new Chart(ctx, {
             type: 'line',


### PR DESCRIPTION
## Summary
- ensure existing chart instances are destroyed before creating new ones

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877da8b63648324955ba895521123ef