### PR TITLE
Add notification for missing product linking dependencies

### DIFF
--- a/core/product-linking-system.js
+++ b/core/product-linking-system.js
@@ -38,7 +38,7 @@ class ProductLinkingSystem {
             
         } catch (error) {
             console.error('❌ Failed to initialize Product Linking System:', error);
-            return false;
+            throw error;
         }
     }
     
@@ -854,11 +854,17 @@ window.productLinking = new ProductLinkingSystem();
 // Auto-inizializza quando DOM è pronto
 if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', () => {
-        window.productLinking.init();
+        window.productLinking.init().catch(() => {
+            window.NotificationSystem?.show('error',
+                'Impossibile inizializzare Product Linking System: dipendenze mancanti');
+        });
     });
 } else {
     // DOM già caricato
-    window.productLinking.init();
+    window.productLinking.init().catch(() => {
+        window.NotificationSystem?.show('error',
+            'Impossibile inizializzare Product Linking System: dipendenze mancanti');
+    });
 }
 
 // ===== API GLOBALI =====

--- a/readme.md
+++ b/readme.md
@@ -118,3 +118,6 @@ Ensure the Netlify project defines the following variables **in the Netlify dash
 Set them in **Site settings → Environment variables**. Functions like `netlify/functions/notifications.js` rely on these values and will fail with `500` errors if missing.
 
 Real‑time features use WebSocket connections to the Supabase URL. Make sure outbound WebSocket traffic is allowed; otherwise the application will fall back to HTTP-only APIs.
+
+If the Product Linking System fails to start because required dependencies are missing,
+the page will now display a notification via `NotificationSystem`.


### PR DESCRIPTION
## Summary
- show an error notification if `ProductLinkingSystem.init()` fails
- document the new behaviour in the README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6877cd54b9e883249e26173e4c5cc08f