### PR TITLE
docs: update field names

### DIFF
--- a/migration/migrate-to-supabase.html
+++ b/migration/migrate-to-supabase.html
@@ -303,14 +303,14 @@
                     // Mappa i campi
                     return {
                         user_id: authData.user.id,
-                        tracking_number: tracking.tracking_number || tracking.trackingNumber,
-                        tracking_type: tracking.tracking_type || tracking.trackingType || 'container',
-                        carrier_code: tracking.carrier_code || tracking.carrier || 'UNKNOWN',
-                        carrier_name: tracking.carrier_name || tracking.carrier_code || tracking.carrier,
-                        reference_number: tracking.reference_number || tracking.reference,
+                        tracking_number: tracking.tracking_number,
+                        tracking_type: tracking.tracking_type || 'container',
+                        carrier_code: tracking.carrier_code || 'UNKNOWN',
+                        carrier_name: tracking.carrier_name || tracking.carrier_code,
+                        reference_number: tracking.reference_number,
                         status: tracking.status || 'registered',
-                        origin_port: tracking.origin_port || tracking.origin,
-                        destination_port: tracking.destination_port || tracking.destination,
+                        origin_port: tracking.origin_port,
+                        destination_port: tracking.destination_port,
                         metadata: {
                             ...tracking.metadata,
                             original_data: tracking,

--- a/pages/shipments/smart-commercial-forms.html
+++ b/pages/shipments/smart-commercial-forms.html
@@ -1776,7 +1776,7 @@
                         <div class="container-fields">
                             <div class="form-group">
                                 <label class="form-label">Numero Container</label>
-                                <input type="text" class="form-input container-input" data-field="containerNumber" placeholder="ABCD1234567">
+                                <input type="text" class="form-input container-input" data-field="tracking_number" placeholder="ABCD1234567">
                             </div>
                             <div class="form-group">
                                 <label class="form-label">Tipo Container</label>

--- a/test-mapping.html
+++ b/test-mapping.html
@@ -78,8 +78,8 @@
                 }
             },
             
-            detectTrackingType(trackingNumber) {
-                const num = trackingNumber.toUpperCase();
+            detectTrackingType(tracking_number) {
+                const num = tracking_number.toUpperCase();
                 for (const [type, pattern] of Object.entries(this.mappings.types)) {
                     if (pattern.test(num)) return type;
                 }
@@ -110,14 +110,14 @@
             },
             
             normalizeTrackingData(row) {
-                const trackingNumber = (
+                const tracking_number = (
                     row['Container'] || 
                     row['AWB Number'] || 
                     row['Tracking Number'] || 
                     ''
                 ).toString().toUpperCase().trim();
                 
-                const trackingType = this.detectTrackingType(trackingNumber);
+                const tracking_type = this.detectTrackingType(tracking_number);
                 
                 const carrierInput = (
                     row['Carrier'] || 
@@ -125,7 +125,7 @@
                     ''
                 ).toString().trim();
                 
-                const carrierCode = this.mappings.carriers[carrierInput] || 
+                const carrier_code = this.mappings.carriers[carrierInput] || 
                                   this.getCarrierCode(carrierInput) ||
                                   carrierInput.toUpperCase();
                 
@@ -133,11 +133,11 @@
                 const status = this.mappings.status[statusInput] || 'registered';
                 
                 return {
-                    trackingNumber,
-                    trackingType,
-                    carrierCode,
+                    tracking_number,
+                    tracking_type,
+                    carrier_code,
                     status,
-                    referenceNumber: row['Reference'] || null,
+                    reference_number: row['Reference'] || null,
                     metadata: {
                         pol: row['Port Of Loading'],
                         pod: row['Port Of Discharge'],
@@ -159,12 +159,12 @@
             // Test Sea Container
             const seaResult = mockImportManager.normalizeTrackingData(testDataSea);
             results.innerHTML += `
-                <div class="test ${seaResult.trackingNumber === 'MSKU1234567' ? 'success' : 'error'}">
+                <div class="test ${seaResult.tracking_number === 'MSKU1234567' ? 'success' : 'error'}">
                     <h3>Test Sea Container</h3>
                     <pre>${JSON.stringify(seaResult, null, 2)}</pre>
-                    <p>✓ Tracking: ${seaResult.trackingNumber} (expected: MSKU1234567)</p>
-                    <p>✓ Type: ${seaResult.trackingType} (expected: container)</p>
-                    <p>✓ Carrier: ${seaResult.carrierCode} (expected: MAERSK)</p>
+                    <p>✓ Tracking: ${seaResult.tracking_number} (expected: MSKU1234567)</p>
+                    <p>✓ Type: ${seaResult.tracking_type} (expected: container)</p>
+                    <p>✓ Carrier: ${seaResult.carrier_code} (expected: MAERSK)</p>
                     <p>✓ Status: ${seaResult.status} (expected: in_transit)</p>
                 </div>
             `;
@@ -172,12 +172,12 @@
             // Test Air Shipment
             const airResult = mockImportManager.normalizeTrackingData(testDataAir);
             results.innerHTML += `
-                <div class="test ${airResult.trackingNumber === '176-12345678' ? 'success' : 'error'}">
+                <div class="test ${airResult.tracking_number === '176-12345678' ? 'success' : 'error'}">
                     <h3>Test Air Shipment</h3>
                     <pre>${JSON.stringify(airResult, null, 2)}</pre>
-                    <p>✓ Tracking: ${airResult.trackingNumber} (expected: 176-12345678)</p>
-                    <p>✓ Type: ${airResult.trackingType} (expected: awb)</p>
-                    <p>✓ Carrier: ${airResult.carrierCode} (expected: CV)</p>
+                    <p>✓ Tracking: ${airResult.tracking_number} (expected: 176-12345678)</p>
+                    <p>✓ Type: ${airResult.tracking_type} (expected: awb)</p>
+                    <p>✓ Carrier: ${airResult.carrier_code} (expected: CV)</p>
                     <p>✓ Status: ${airResult.status} (expected: in_transit)</p>
                 </div>
             `;
@@ -185,11 +185,11 @@
             // Test what would be saved
             const mockTracking = {
                 id: Date.now(),
-                tracking_number: seaResult.trackingNumber,
-                tracking_type: seaResult.trackingType,
-                carrier_code: seaResult.carrierCode,
+                tracking_number: seaResult.tracking_number,
+                tracking_type: seaResult.tracking_type,
+                carrier_code: seaResult.carrier_code,
                 status: seaResult.status,
-                reference_number: seaResult.referenceNumber,
+                reference_number: seaResult.reference_number,
                 origin_port: seaResult.metadata.pol || 'N/A',
                 destination_port: seaResult.metadata.pod || 'N/A',
                 eta: seaResult.metadata.discharge_date,

--- a/test-phase3.html
+++ b/test-phase3.html
@@ -521,13 +521,13 @@
         
         // Test 3: Workflow
         async function testWorkflow() {
-            const containerNumber = document.getElementById('test-container').value.trim().toUpperCase();
-            if (!containerNumber) {
+            const tracking_number = document.getElementById('test-container').value.trim().toUpperCase();
+            if (!tracking_number) {
                 alert('Inserisci un numero di container');
                 return;
             }
             
-            log(`Starting workflow test for container: ${containerNumber}`);
+            log(`Starting workflow test for container: ${tracking_number}`);
             updateStatus('workflow-status', 'pending', 'Testing workflow...');
             document.getElementById('workflow-result').innerHTML = '';
             
@@ -544,7 +544,7 @@
                         contentType: 'application/x-www-form-urlencoded',
                         data: {
                             authCode: '2dc0c6d92ccb59e7d903825c4ebeb521', // Demo key
-                            containerNumber: containerNumber,
+                            tracking_number: tracking_number,
                             shippingLine: 'OTHERS'
                         }
                     })
@@ -553,7 +553,7 @@
                 const postResult = await postResponse.json();
                 log(`POST Result: ${JSON.stringify(postResult)}`, postResult.success ? 'success' : 'error');
                 
-                let requestId = containerNumber;
+                let requestId = tracking_number;
                 
                 if (postResult.success) {
                     // Extract requestId if available
@@ -606,7 +606,7 @@
                     showResult('workflow-result', {
                         workflow: 'POST → GET Success',
                         requestId: requestId,
-                        container: containerNumber,
+                        tracking_number: tracking_number,
                         data: containerData
                     });
                     log(`✅ Workflow completed successfully`, 'success');
@@ -631,7 +631,7 @@
             log('Testing ALREADY_EXISTS error handler...');
             if (window.TrackingErrorHandler) {
                 window.TrackingErrorHandler.showError('ALREADY_EXISTS', {
-                    trackingNumber: 'MSKU1234567',
+                    tracking_number: 'MSKU1234567',
                     requestId: '5051594',
                     details: 'Container MSKU1234567 already exists with requestId: 5051594'
                 });
@@ -647,7 +647,7 @@
             log('Testing INVALID_FORMAT error handler...');
             if (window.TrackingErrorHandler) {
                 window.TrackingErrorHandler.showError('INVALID_FORMAT', {
-                    trackingNumber: 'INVALID123',
+                    tracking_number: 'INVALID123',
                     details: 'The tracking number INVALID123 is not in a recognized format'
                 });
                 updateStatus('format-status', 'success', '✅ Shown');
@@ -699,7 +699,7 @@
                             workflow.updateStep('step-fetch', 'success', 'Data retrieved');
                             workflow.showResult({
                                 success: true,
-                                containerNumber: 'TEST123456',
+                                tracking_number: 'TEST123456',
                                 requestId: '12345',
                                 status: 'In Transit',
                                 vessel: 'MSC OSCAR'


### PR DESCRIPTION
## Summary
- rename containerNumber usages in examples to tracking_number
- unify variable names in tracking mapping example
- update migration helper code for new field names
- adjust smart commercial form placeholders

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6878a9968e3c8324b4325e9b58f7f7db