### PR TITLE
fix: update shipments registry date formatting

### DIFF
--- a/core/shipments-registry.js
+++ b/core/shipments-registry.js
@@ -1,4 +1,5 @@
-import { formatDate, formatCurrency, getShipmentStatusClass } from './table-config.js';
+import { formatCurrency, getShipmentStatusClass } from './table-config.js';
+import { formatDate } from '../pages/tracking/table-columns-legacy.js';
 console.log('[ShipmentsRegistry] Loading...');
 
 const ShipmentsRegistry = {


### PR DESCRIPTION
## Summary
- import `formatDate` from tracking legacy columns
- keep existing currency and status helpers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6878aa28683c8324aa88931d1ad6b68f