### PR TITLE
docs: update tracking examples

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -45,7 +45,8 @@ In today's global supply chain, **visibility is everything**. Lost shipments, de
 
 ### 📄 Tracking object format
 
-Trackings share a common structure across the project. See `core/typedefs.d.ts` for all fields.
+Trackings share a common structure across the project. See `core/typedefs.d.ts` for the base
+`TrackingLike` definition used throughout the codebase.
 
 ```js
 /** @type {TrackingLike} */

--- a/tracking.html
+++ b/tracking.html
@@ -652,9 +652,11 @@ window.addEventListener('DOMContentLoaded', () => {
                                         /** @type {TrackingLike} */
                                         const trackingData = {
                                             tracking_number: document.querySelector('#trackingNumber').value,
-                                            carrier: document.querySelector('#carrier').value,
                                             tracking_type: document.querySelector('#trackingType').value || 'container',
-                                            origin: document.querySelector('#origin').value,
+                                            origin_port: document.querySelector('#origin').value,
+                                            origin_country: '',
+                                            eta: '',
+                                            carrier: document.querySelector('#carrier').value,
                                             destination: document.querySelector('#destination').value,
                                             status: 'pending',
                                             // AGGIUNGI QUESTI CAMPI OBBLIGATORI:


### PR DESCRIPTION
## Summary
- showcase `TrackingLike` usage in docs
- update example in `tracking.html` to align with global typedef

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6878ab04e7ec83248beafaae42317ca5