### PR TITLE
Fix retry loops with max attempts

### DIFF
--- a/assets/js/column-fix-debug.js
+++ b/assets/js/column-fix-debug.js
@@ -8,11 +8,19 @@
     
     // Aspetta che il sistema tracking sia caricato
     function waitForTrackingSystem() {
+        waitForTrackingSystem.retryCount = waitForTrackingSystem.retryCount || 0;
+        if (waitForTrackingSystem.retryCount >= 10) {
+            console.error(`servizio non disponibile dopo ${waitForTrackingSystem.retryCount} tentativi`);
+            return;
+        }
+
         if (typeof window.getColumnFormatter === 'function') {
             console.log('✅ Tracking system found, applying fixes...');
+            waitForTrackingSystem.retryCount = 0;
             applyColumnFixes();
         } else {
             console.log('⏳ Waiting for tracking system...');
+            waitForTrackingSystem.retryCount++;
             setTimeout(waitForTrackingSystem, 500);
         }
     }

--- a/pages/tracking/tracking-complete-fix-v2.js
+++ b/pages/tracking/tracking-complete-fix-v2.js
@@ -29,6 +29,13 @@
     
     // New function to handle drag&drop functionality
     function enableColumnDragDrop() {
+        enableColumnDragDrop.retryCount = enableColumnDragDrop.retryCount || 0;
+        if (enableColumnDragDrop.retryCount >= 10) {
+            console.error(`servizio non disponibile dopo ${enableColumnDragDrop.retryCount} tentativi`);
+            return;
+        }
+        enableColumnDragDrop.retryCount++;
+
         console.log('🔧 Enabling column drag&drop...');
         
         // Wait for TableManager to be ready
@@ -89,6 +96,7 @@
             });
             
             console.log('✅ Column drag&drop enabled successfully');
+            enableColumnDragDrop.retryCount = 0;
             
             // Add CSS for drag&drop visual feedback
             if (!document.getElementById('sortable-drag-styles')) {
@@ -142,11 +150,19 @@
     // FIX 2: OCEAN API v2.0 IMPLEMENTATION
     // ========================================
     function implementOceanV2API() {
+        implementOceanV2API.retryCount = implementOceanV2API.retryCount || 0;
+        if (implementOceanV2API.retryCount >= 10) {
+            console.error(`servizio non disponibile dopo ${implementOceanV2API.retryCount} tentativi`);
+            return;
+        }
+
         if (!window.trackingService) {
             console.warn('⏳ Waiting for trackingService...');
+            implementOceanV2API.retryCount++;
             setTimeout(implementOceanV2API, 500);
             return;
         }
+        implementOceanV2API.retryCount = 0;
         
         console.log('🔧 Implementing Ocean v2.0 API methods...');
         


### PR DESCRIPTION
## Summary
- limit retry attempts in `enableColumnDragDrop` and reset counter on success
- apply same max retry logic in `implementOceanV2API`
- add retry cap for `waitForTrackingSystem`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6878b7ca19f88324a0041c01602dc99d