### PR TITLE
fix: tracking service load order

### DIFF
--- a/pages/tracking/index.js
+++ b/pages/tracking/index.js
@@ -197,7 +197,8 @@ const DEFAULT_VISIBLE_COLUMNS = [
 // Initialize
 document.addEventListener('DOMContentLoaded', async () => {
     console.log('🚀 Initializing tracking page...');
-    
+    await waitForGlobal('trackingService', 20);
+
     try {
         // Hide loading state
         document.getElementById('loadingState').style.display = 'none';

--- a/tracking.html
+++ b/tracking.html
@@ -582,6 +582,8 @@ window.performanceReport = function() {
     // ... resto del codice ...
 };
 </script>
+    <!-- Load Tracking Service before page logic -->
+    <script type="module" src="/core/services/tracking-service.js"></script>
     <!-- Page Logic -->
     <script type="module" src="/pages/tracking/index.js"></script>
     <!-- FIX: Assicura che showAddTrackingForm sia disponibile -->
@@ -711,9 +713,6 @@ setTimeout(() => {
 }, 2000);
 </script>
 
-    <!-- Load Tracking Service -->
-    <script type="module" src="/core/services/tracking-service.js"></script>
-    
     <!-- Load Progressive Form -->
     <script src="/pages/tracking/tracking-form-progressive.js"></script>
     


### PR DESCRIPTION
## Summary
- load `/core/services/tracking-service.js` before `index.js` in tracking.html
- wait for `window.trackingService` when tracking page initializes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6878c18315448324a1812d91d3986152