### PR TITLE
Update table when services missing

### DIFF
--- a/pages/tracking/index.js
+++ b/pages/tracking/index.js
@@ -370,6 +370,29 @@ function detectTrackingType(trackingNumber) {
 // Update table
 function updateTable() {
     try {
+        const tableBody = document.querySelector('#tracking-table tbody');
+
+        if (!window.trackingService) {
+            if (tableBody) {
+                tableBody.innerHTML = '<tr><td colspan="99">Tracking Service non disponibile</td></tr>';
+            }
+            return;
+        }
+
+        if (!window.tableManager) {
+            if (tableBody) {
+                tableBody.innerHTML = '<tr><td colspan="99">Table Manager non disponibile</td></tr>';
+            }
+            return;
+        }
+
+        if (filteredTrackings.length === 0) {
+            if (tableBody) {
+                tableBody.innerHTML = '<tr><td colspan="99">Nessun tracking trovato</td></tr>';
+            }
+            return;
+        }
+
         if (tableManager) {
             tableManager.setData(filteredTrackings);
 


### PR DESCRIPTION
## Summary
- show error rows in the tracking table when `trackingService` or `tableManager` are unavailable
- show message when no trackings are found

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6878c1ba9370832490781a16de5ff40d