### PR TITLE
fix: add tracking load debug log

### DIFF
--- a/assets/js/tracking-page.js
+++ b/assets/js/tracking-page.js
@@ -82,6 +82,7 @@ class TrackingPage {
             if (loadingEl) loadingEl.style.display = 'block';
 
             const trackings = await dataManager.getTrackings(this.filters);
+            console.log(`[DEBUG] Tracking caricati: ${trackings.length}`, trackings);
             this.renderTrackings(trackings);
 
             // Update stats

--- a/pages/tracking/index.js
+++ b/pages/tracking/index.js
@@ -343,7 +343,8 @@ async function loadTrackings() {
                 }
             ];
         }
-        
+
+        console.log(`[DEBUG] Tracking caricati: ${trackings.length}`, trackings);
         filteredTrackings = [...trackings];
         updateTable();
         updateStats();


### PR DESCRIPTION
## Summary
- add debug log after loading trackings in modern page script
- log loaded trackings in legacy tracking page script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6878c1e7068883248483f146c1e6ac22