### PR TITLE
Add confirm before deleting tracking

### DIFF
--- a/pages/tracking/index.js
+++ b/pages/tracking/index.js
@@ -934,7 +934,7 @@ function viewDetails(id) {
 }
 
 async function deleteTracking(id) {
-    if (!confirm('Eliminare questo tracking?')) return;
+    if (!confirm('⚠️ Questa operazione eliminerà anche la spedizione collegata. Procedere?')) return;
     
     try {
         // Usa il dataManager per eliminare tracking e spedizione associata
@@ -1364,8 +1364,10 @@ async function performBulkAction(action) {
             break;
             
         case 'delete':
-            if (confirm(`Eliminare ${selected.length} tracking?`)) {
-                window.NotificationSystem?.info('Eliminazione in corso...');
+            if (!confirm('⚠️ Questa operazione eliminerà anche la spedizione collegata. Procedere?')) {
+                break;
+            }
+            window.NotificationSystem?.info('Eliminazione in corso...');
                 
                 let deleted = 0;
                 for (const row of selected) {

--- a/pages/tracking/tracking-complete-fix.js
+++ b/pages/tracking/tracking-complete-fix.js
@@ -598,7 +598,7 @@
                 });
             } else {
                 // Fallback confirm
-                if (confirm(`Eliminare ${trackingNumber}?`)) {
+                if (confirm('⚠️ Questa operazione eliminerà anche la spedizione collegata. Procedere?')) {
                     await performDelete(id);
                 }
             }

--- a/pages/tracking/tracking-init-fix.js
+++ b/pages/tracking/tracking-init-fix.js
@@ -308,7 +308,7 @@ Ultimo aggiornamento: ${tracking.last_update || tracking.updated_at || '-'}
             window.deleteTracking = async function(id) {
                 console.log('🗑️ Deleting tracking:', id);
                 
-                if (!confirm('Eliminare questo tracking?')) {
+                if (!confirm('⚠️ Questa operazione eliminerà anche la spedizione collegata. Procedere?')) {
                     return;
                 }
                 
@@ -433,10 +433,11 @@ Ultimo aggiornamento: ${tracking.last_update || tracking.updated_at || '-'}
                 
                 switch(action) {
                     case 'delete':
-                        if (confirm(`Eliminare ${selected.length} tracking?`)) {
-                            for (const id of selected) {
-                                await window.deleteTracking(id);
-                            }
+                        if (!confirm('⚠️ Questa operazione eliminerà anche la spedizione collegata. Procedere?')) {
+                            break;
+                        }
+                        for (const id of selected) {
+                            await window.deleteTracking(id);
                         }
                         break;
                         


### PR DESCRIPTION
## Summary
- confirm deletion of a single tracking also removes the shipment
- confirm bulk deletion also removes linked shipments

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687abf77eeb8832499b312ef70fd98b5