### PR TITLE
Fix stray brace in tracking index.js

### DIFF
--- a/pages/tracking/index.js
+++ b/pages/tracking/index.js
@@ -1392,7 +1392,6 @@ async function performBulkAction(action) {
                 tableManager.clearSelection();
                 
                 window.NotificationSystem?.success(`Eliminati ${deleted} tracking`);
-            }
             break;
     }
 }


### PR DESCRIPTION
## Summary
- fix unmatched closing brace in `pages/tracking/index.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ad2ea00ec8324897c7a05bc91d360