### PR TITLE
Fix Supabase tracking initialization

### DIFF
--- a/pages/tracking/index.js
+++ b/pages/tracking/index.js
@@ -1,6 +1,12 @@
 // index.js - Clean tracking page logic with all mappings
 import TableManager from '/core/table-manager.js';
 import { trackingsColumns, formatDate, formatDateOnly, formatTrackingStatus } from '/core/table-config.js';
+import supabaseTrackingService from '/core/services/supabase-tracking-service.js';
+
+// Ensure global supabaseTrackingService
+if (typeof window !== 'undefined' && !window.supabaseTrackingService) {
+    window.supabaseTrackingService = supabaseTrackingService;
+}
 
 // State
 let trackings = [];


### PR DESCRIPTION
## Summary
- expose `supabaseTrackingService` globally in tracking page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c178136b08324a0701e739d23af78