### PR TITLE
Update TableManager to handle UUID row IDs

### DIFF
--- a/core/table-manager.js
+++ b/core/table-manager.js
@@ -270,8 +270,8 @@ export class TableManager {
     
     // Render select all checkbox header
     renderSelectAllHeader() {
-        const allSelected = this.displayData.length > 0 && 
-                          this.displayData.every(row => this.selectedRows.has(row.id || this.data.indexOf(row)));
+        const allSelected = this.displayData.length > 0 &&
+                          this.displayData.every(row => this.selectedRows.has(String(row.id ?? this.data.indexOf(row))));
         
         return `
             <th class="no-drag" style="width: 40px;">
@@ -309,7 +309,7 @@ export class TableManager {
     
     // Render table row
     renderRow(row, index) {
-        const rowId = row.id || index;
+        const rowId = String(row.id ?? index);
         const isSelected = this.selectedRows.has(rowId);
         
         return `
@@ -718,7 +718,7 @@ export class TableManager {
     selectAll(selected) {
         if (selected) {
             this.displayData.forEach(row => {
-                const id = row.id || this.data.indexOf(row);
+                const id = String(row.id ?? this.data.indexOf(row));
                 this.selectedRows.add(id);
             });
         } else {
@@ -731,7 +731,7 @@ export class TableManager {
     
     // Select/deselect single row
     selectRow(rowId, selected) {
-        const id = parseInt(rowId);
+        const id = String(rowId);
         
         if (selected) {
             this.selectedRows.add(id);
@@ -746,7 +746,7 @@ export class TableManager {
     // Get selected rows data
     getSelectedRows() {
         return this.data.filter(row => {
-            const id = row.id || this.data.indexOf(row);
+            const id = String(row.id ?? this.data.indexOf(row));
             return this.selectedRows.has(id);
         });
     }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "> **Transform your supply chain chaos into clarity.** Real-time tracking, intelligent insights, and seamless logistics management - all in one powerful platform.",
   "main": "phase2-architecture.js",
   "scripts": {
-    "test": "node tests/user-settings-service.test.mjs && node tests/supabase-env-check.test.mjs && node tests/shipments-initialization.test.mjs"
+    "test": "node tests/user-settings-service.test.mjs && node tests/supabase-env-check.test.mjs && node tests/shipments-initialization.test.mjs && node tests/table-manager-select.test.mjs"
   },
   "repository": {
     "type": "git",

--- a/tests/table-manager-select.test.mjs
+++ b/tests/table-manager-select.test.mjs
@@ -1,0 +1,52 @@
+import assert from 'assert';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Minimal DOM mocks
+const container = {
+    id: 'tbl',
+    innerHTML: '',
+    addEventListener() {},
+    querySelector() { return null; }
+};
+
+global.document = {
+    getElementById(id) { return container; }
+};
+
+global.window = {};
+
+global.localStorage = {
+    getItem() { return null; },
+    setItem() {}
+};
+
+// Load module via data URL to force ESM interpretation
+const code = readFileSync(join(__dirname, '../core/table-manager.js'), 'utf8');
+const moduleUrl = 'data:text/javascript;base64,' + Buffer.from(code).toString('base64');
+const { TableManager } = await import(moduleUrl);
+
+// Disable rendering and events for the test
+TableManager.prototype.render = function() {};
+TableManager.prototype.attachEventListeners = function() {};
+TableManager.prototype.enableColumnDrag = function() {};
+TableManager.prototype.initAdvancedSearch = function() {};
+TableManager.prototype.loadColumnOrder = function() {};
+
+const tm = new TableManager('tbl', { selectable: true });
+
+tm.setData([
+    { id: 'a1b2', name: 'One' },
+    { id: 'c3d4', name: 'Two' }
+]);
+
+tm.selectRow('a1b2', true);
+assert.deepStrictEqual(tm.getSelectedRows().map(r => r.id), ['a1b2']);
+
+tm.selectRow('c3d4', true);
+assert.ok(tm.renderSelectAllHeader().includes('checked'));
+
+console.log('TableManager UUID select test passed');


### PR DESCRIPTION
## Summary
- allow TableManager selection to work with UUID identifiers
- test selecting rows with UUIDs

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687cdb04ee8083249daba72fe26e4623