### PR TITLE
Fix default columns array closure

### DIFF
--- a/pages/tracking/index.js
+++ b/pages/tracking/index.js
@@ -139,7 +139,7 @@ const DEFAULT_VISIBLE_COLUMNS = [
     'transit_time',         // ← Aggiungi
     'co2_emission',         // ← Aggiungi
     'last_update'
-};
+];
 
 // Column configuration for table
 const TABLE_COLUMNS = trackingsColumns;


### PR DESCRIPTION
## Summary
- close DEFAULT_VISIBLE_COLUMNS array in tracking page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e3197433883249357a01e28e901d4