### PR TITLE
Fix event listeners closure

### DIFF
--- a/pages/tracking/index.js
+++ b/pages/tracking/index.js
@@ -396,13 +396,15 @@ function setupEventListeners() {
     window.COLUMN_MAPPING = COLUMN_MAPPING;
     window.STATUS_DISPLAY = STATUS_DISPLAY;
     window.getStatusMapping = getStatusMapping;
- window.updateBulkActionsBar = function() {
+    window.updateBulkActionsBar = function() {
         // Delega a handleSelectionChange che già esiste
         if (tableManager) {
             const selected = tableManager.getSelectedRows();
             handleSelectionChange(selected);
         }
     };
+
+}
 
 function showColumnEditor() {
     if (!window.ModalSystem) return;


### PR DESCRIPTION
## Summary
- close the `setupEventListeners` function in tracking page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687e337ab7f883249742b664b23c01ee