### PR TITLE
Update showColumnEditor modal close

### DIFF
--- a/pages/tracking/index.js
+++ b/pages/tracking/index.js
@@ -377,7 +377,7 @@ function showColumnEditor() {
         content: `<p class="text-muted">Seleziona e riordina le colonne da visualizzare.</p><ul class="list-group" id="column-editor-list">${listContent}</ul>`,
         size: 'large',
         buttons: [
-            { text: 'Annulla', className: 'btn-secondary', action: () => ModalSystem.hide() },
+            { text: 'Annulla', className: 'btn-secondary', action: () => ModalSystem.close() },
             {
                 text: 'Salva',
                 className: 'btn-primary',
@@ -395,7 +395,7 @@ function showColumnEditor() {
                     if (success) {
                         const newColumns = getFormattedColumns(newVisibleKeys);
                         tableManager.updateColumns(newColumns);
-                        ModalSystem.hide();
+                        ModalSystem.close();
                         showNotification('Preferenze colonne salvate.', 'success');
                     } else {
                         showError('Errore nel salvataggio delle preferenze.');


### PR DESCRIPTION
## Summary
- replace deprecated `ModalSystem.hide()` with `ModalSystem.close()` in column editor

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883d41f838c83249e0271f3aa97d436