### PR TITLE
Disable default column manager button

### DIFF
--- a/pages/tracking/index.js
+++ b/pages/tracking/index.js
@@ -140,6 +140,7 @@ async function initializeTableManager() {
         columns: initialColumns,
         selectable: true,
         searchable: false,
+        enableColumnManager: false,
         paginate: true,
         pageSize: 25,
         onSelectionChange: handleSelectionChange,


### PR DESCRIPTION
## Summary
- disable TableManager built-in column manager in tracking page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883d58f03408324aa0b8314a15928ca